### PR TITLE
Improve const-correctness of API

### DIFF
--- a/rmf_task/include/rmf_task/CostCalculator.hpp
+++ b/rmf_task/include/rmf_task/CostCalculator.hpp
@@ -25,6 +25,9 @@ namespace rmf_task {
 // Forward declare abstract interface. The definition will remain as internal detail.
 class CostCalculator;
 
+using CostCalculatorPtr = std::shared_ptr<CostCalculator>;
+using ConstCostCalculatorPtr = std::shared_ptr<const CostCalculator>;
+
 } // namespace rmf_task
 
 # endif // RMF_TASK__COSTCALCULATOR_HPP

--- a/rmf_task/include/rmf_task/agv/TaskPlanner.hpp
+++ b/rmf_task/include/rmf_task/agv/TaskPlanner.hpp
@@ -53,57 +53,59 @@ public:
     ///   The battery system of the robot
     ///
     /// \param[in] motion_sink
-    ///   The motion sink of the robot
+    ///   The motion sink of the robot. This describes how power gets drained
+    ///   while the robot is moving.
     ///
-    /// \param[in] device_sink
-    ///   The ambient device sink of the robot
+    /// \param[in] ambient_sink
+    ///   The ambient device sink of the robot. This describes how power gets
+    ///   drained at all times from passive use of the robot's electronics.
     ///
     /// \param[in] planner
     ///   The planner for a robot in this fleet
     ///
-    /// \param[in] filter_type
-    ///   The type of filter used for planning
+    /// \param[in] cost_calculator
+    ///   An object that tells the planner how to calculate cost
     Configuration(
       rmf_battery::agv::BatterySystem battery_system,
-      std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-      std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
-      std::shared_ptr<rmf_traffic::agv::Planner> planner,
-      std::shared_ptr<rmf_task::CostCalculator> cost_calculator);
+      rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+      rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+      std::shared_ptr<const rmf_traffic::agv::Planner> planner,
+      ConstCostCalculatorPtr cost_calculator);
 
     /// Get the battery system
-    const rmf_battery::agv::BatterySystem& battery_system();
+    const rmf_battery::agv::BatterySystem& battery_system() const;
 
     /// Set the battery_system
     Configuration& battery_system(
       rmf_battery::agv::BatterySystem battery_system);
 
     /// Get the motion sink
-    const std::shared_ptr<rmf_battery::MotionPowerSink>& motion_sink() const;
+    const rmf_battery::ConstMotionPowerSinkPtr& motion_sink() const;
 
     /// Set the motion_sink
     Configuration& motion_sink(
-      std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink);
+      rmf_battery::ConstMotionPowerSinkPtr motion_sink);
 
     /// Get the ambient device sink
-    const std::shared_ptr<rmf_battery::DevicePowerSink>& ambient_sink() const;
+    const rmf_battery::ConstDevicePowerSinkPtr& ambient_sink() const;
 
     /// Set the ambient device sink
     Configuration& ambient_sink(
-      std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink);
+      rmf_battery::ConstDevicePowerSinkPtr ambient_sink);
 
     /// Get the planner
-    const std::shared_ptr<rmf_traffic::agv::Planner>& planner() const;
+    const std::shared_ptr<const rmf_traffic::agv::Planner>& planner() const;
 
     /// Set the planner
-    Configuration& planner(std::shared_ptr<rmf_traffic::agv::Planner> planner);
+    Configuration& planner(
+      std::shared_ptr<const rmf_traffic::agv::Planner> planner);
 
     /// Get the CostCalculator
-    const std::shared_ptr<rmf_task::CostCalculator>& cost_calculator() const;
+    const ConstCostCalculatorPtr& cost_calculator() const;
 
     /// Set the CostCalculator. If a nullptr is passed, the
     /// BinaryPriorityCostCalculator is used by the planner.
-    Configuration& cost_calculator(
-      std::shared_ptr<rmf_task::CostCalculator> cost_calculator);
+    Configuration& cost_calculator(ConstCostCalculatorPtr cost_calculator);
 
     class Implementation;
 
@@ -168,10 +170,10 @@ public:
   ///
   /// \param[in] config
   /// The configuration for the planner
-  TaskPlanner(std::shared_ptr<Configuration> config);
+  TaskPlanner(const Configuration& config);
 
   /// Get a shared pointer to the configuration of this task planner
-  const std::shared_ptr<Configuration>& config() const;
+  const Configuration& config() const;
 
   /// Get the greedy planner based assignments for a set of initial states and 
   /// requests

--- a/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
@@ -42,9 +42,9 @@ public:
 
   static DescriptionPtr make(
     rmf_battery::agv::BatterySystem battery_system,
-    std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> device_sink,
-    std::shared_ptr<rmf_traffic::agv::Planner> planner,
+    rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+    rmf_battery::ConstDevicePowerSinkPtr device_sink,
+    std::shared_ptr<const rmf_traffic::agv::Planner> planner,
     rmf_traffic::Time start_time,
     bool drain_battery = true);
 
@@ -75,9 +75,9 @@ public:
 
   static ConstRequestPtr make(
     rmf_battery::agv::BatterySystem battery_system,
-    std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> device_sink,
-    std::shared_ptr<rmf_traffic::agv::Planner> planner,
+    rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+    rmf_battery::ConstDevicePowerSinkPtr device_sink,
+    std::shared_ptr<const rmf_traffic::agv::Planner> planner,
     rmf_traffic::Time start_time,
     bool drain_battery = true,
     ConstPriorityPtr priority = nullptr);

--- a/rmf_task/include/rmf_task/requests/Clean.hpp
+++ b/rmf_task/include/rmf_task/requests/Clean.hpp
@@ -44,11 +44,11 @@ public:
   static DescriptionPtr make(
     std::size_t start_waypoint,
     std::size_t end_waypoint,
-    rmf_traffic::Trajectory& cleaning_path,
-    std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> cleaning_sink,
-    std::shared_ptr<rmf_traffic::agv::Planner> planner,
+    const rmf_traffic::Trajectory& cleaning_path,
+    rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+    rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+    rmf_battery::ConstDevicePowerSinkPtr cleaning_sink,
+    std::shared_ptr<const rmf_traffic::agv::Planner> planner,
     rmf_traffic::Time start_time,
     bool drain_battery = true);
 
@@ -85,11 +85,11 @@ public:
     const std::string& id,
     std::size_t start_waypoint,
     std::size_t end_waypoint,
-    rmf_traffic::Trajectory& cleaning_path,
-    std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> cleaning_sink,
-    std::shared_ptr<rmf_traffic::agv::Planner> planner,
+    const rmf_traffic::Trajectory& cleaning_path,
+    rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+    rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+    rmf_battery::ConstDevicePowerSinkPtr cleaning_sink,
+    std::shared_ptr<const rmf_traffic::agv::Planner> planner,
     rmf_traffic::Time start_time,
     bool drain_battery = true,
     ConstPriorityPtr priority = nullptr);

--- a/rmf_task/include/rmf_task/requests/Delivery.hpp
+++ b/rmf_task/include/rmf_task/requests/Delivery.hpp
@@ -51,9 +51,9 @@ public:
     std::size_t dropoff_waypoint,
     std::string dropoff_ingestor,
     std::vector<DispenserRequestItem> items,
-    std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> device_sink,
-    std::shared_ptr<rmf_traffic::agv::Planner> planner,
+    rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+    rmf_battery::ConstDevicePowerSinkPtr device_sink,
+    std::shared_ptr<const rmf_traffic::agv::Planner> planner,
     rmf_traffic::Time start_time,
     bool drain_battery = true);
 
@@ -104,9 +104,9 @@ public:
     std::size_t dropoff_waypoint,
     std::string dropoff_ingestor,
     std::vector<DispenserRequestItem> items,
-    std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> device_sink,
-    std::shared_ptr<rmf_traffic::agv::Planner> planner,
+    rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+    rmf_battery::ConstDevicePowerSinkPtr device_sink,
+    std::shared_ptr<const rmf_traffic::agv::Planner> planner,
     rmf_traffic::Time start_time,
     bool drain_battery = true,
     ConstPriorityPtr priority = nullptr);

--- a/rmf_task/include/rmf_task/requests/Loop.hpp
+++ b/rmf_task/include/rmf_task/requests/Loop.hpp
@@ -47,9 +47,9 @@ public:
     std::size_t start_waypoint,
     std::size_t finish_waypoint,
     std::size_t num_loops,
-    std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
-    std::shared_ptr<rmf_traffic::agv::Planner> planner,
+    rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+    rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+    std::shared_ptr<const rmf_traffic::agv::Planner> planner,
     rmf_traffic::Time start_time,
     bool drain_battery = true);
   
@@ -93,9 +93,9 @@ public:
     std::size_t start_waypoint,
     std::size_t finish_waypoint,
     std::size_t num_loops,
-    std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
-    std::shared_ptr<rmf_traffic::agv::Planner> planner,
+    rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+    rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+    std::shared_ptr<const rmf_traffic::agv::Planner> planner,
     rmf_traffic::Time start_time,
     bool drain_battery = true,
     ConstPriorityPtr priority = nullptr);

--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -49,10 +49,10 @@ std::string generate_uuid(const std::size_t length = 3)
 class ChargeBatteryDescription::Implementation
 {
 public:
-  rmf_battery::agv::BatterySystemPtr battery_system;
-  std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink;
-  std::shared_ptr<rmf_battery::DevicePowerSink> device_sink;
-  std::shared_ptr<rmf_traffic::agv::Planner> planner;
+  rmf_battery::agv::ConstBatterySystemPtr battery_system;
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink;
+  rmf_battery::ConstDevicePowerSinkPtr device_sink;
+  std::shared_ptr<const rmf_traffic::agv::Planner> planner;
   rmf_traffic::Time start_time;
   bool drain_battery;
 
@@ -64,9 +64,9 @@ public:
 //==============================================================================
 rmf_task::DescriptionPtr ChargeBatteryDescription::make(
   rmf_battery::agv::BatterySystem battery_system,
-  std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-  std::shared_ptr<rmf_battery::DevicePowerSink> device_sink,
-  std::shared_ptr<rmf_traffic::agv::Planner> planner,
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+  rmf_battery::ConstDevicePowerSinkPtr device_sink,
+  std::shared_ptr<const rmf_traffic::agv::Planner> planner,
   rmf_traffic::Time start_time,
   bool drain_battery)
 {
@@ -210,9 +210,9 @@ double ChargeBatteryDescription::max_charge_soc() const
 //==============================================================================
 ConstRequestPtr ChargeBattery::make(
   rmf_battery::agv::BatterySystem battery_system,
-  std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-  std::shared_ptr<rmf_battery::DevicePowerSink> device_sink,
-  std::shared_ptr<rmf_traffic::agv::Planner> planner,
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+  rmf_battery::ConstDevicePowerSinkPtr device_sink,
+  std::shared_ptr<const rmf_traffic::agv::Planner> planner,
   rmf_traffic::Time start_time,
   bool drain_battery,
   ConstPriorityPtr priority)

--- a/rmf_task/src/rmf_task/requests/Clean.cpp
+++ b/rmf_task/src/rmf_task/requests/Clean.cpp
@@ -33,10 +33,10 @@ public:
   std::size_t start_waypoint;
   std::size_t end_waypoint;
   rmf_traffic::Trajectory cleaning_path;
-  std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink;
-  std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink;
-  std::shared_ptr<rmf_battery::DevicePowerSink> cleaning_sink;
-  std::shared_ptr<rmf_traffic::agv::Planner> planner;
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink;
+  rmf_battery::ConstDevicePowerSinkPtr ambient_sink;
+  rmf_battery::ConstDevicePowerSinkPtr cleaning_sink;
+  std::shared_ptr<const rmf_traffic::agv::Planner> planner;
   rmf_traffic::Time start_time;
   bool drain_battery;
 
@@ -48,11 +48,11 @@ public:
 rmf_task::DescriptionPtr CleanDescription::make(
   std::size_t start_waypoint,
   std::size_t end_waypoint,
-  rmf_traffic::Trajectory& cleaning_path,
-  std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-  std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
-  std::shared_ptr<rmf_battery::DevicePowerSink> cleaning_sink,
-  std::shared_ptr<rmf_traffic::agv::Planner> planner,
+  const rmf_traffic::Trajectory& cleaning_path,
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+  rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+  rmf_battery::ConstDevicePowerSinkPtr cleaning_sink,
+  std::shared_ptr<const rmf_traffic::agv::Planner> planner,
   rmf_traffic::Time start_time,
   bool drain_battery)
 {
@@ -312,11 +312,11 @@ ConstRequestPtr Clean::make(
     const std::string& id,
     std::size_t start_waypoint,
     std::size_t end_waypoint,
-    rmf_traffic::Trajectory& cleaning_path,
-    std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> cleaning_sink,
-    std::shared_ptr<rmf_traffic::agv::Planner> planner,
+    const rmf_traffic::Trajectory& cleaning_path,
+    rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+    rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+    rmf_battery::ConstDevicePowerSinkPtr cleaning_sink,
+    std::shared_ptr<const rmf_traffic::agv::Planner> planner,
     rmf_traffic::Time start_time,
     bool drain_battery,
     ConstPriorityPtr priority)

--- a/rmf_task/src/rmf_task/requests/Delivery.cpp
+++ b/rmf_task/src/rmf_task/requests/Delivery.cpp
@@ -35,9 +35,9 @@ public:
   std::size_t dropoff_waypoint;
   std::string dropoff_ingestor;
   std::vector<DispenserRequestItem> items;
-  std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink;
-  std::shared_ptr<rmf_battery::DevicePowerSink> device_sink;
-  std::shared_ptr<rmf_traffic::agv::Planner> planner;
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink;
+  rmf_battery::ConstDevicePowerSinkPtr device_sink;
+  std::shared_ptr<const rmf_traffic::agv::Planner> planner;
   rmf_traffic::Time start_time;
   bool drain_battery;
 
@@ -52,9 +52,9 @@ rmf_task::DescriptionPtr DeliveryDescription::make(
   std::size_t dropoff_waypoint,
   std::string dropoff_ingestor,
   std::vector<DispenserRequestItem> items,
-  std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-  std::shared_ptr<rmf_battery::DevicePowerSink> device_sink,
-  std::shared_ptr<rmf_traffic::agv::Planner> planner,
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+  rmf_battery::ConstDevicePowerSinkPtr device_sink,
+  std::shared_ptr<const rmf_traffic::agv::Planner> planner,
   rmf_traffic::Time start_time,
   bool drain_battery)
 {
@@ -337,16 +337,15 @@ DeliveryDescription::Start DeliveryDescription::dropoff_start(
 }
 
 //==============================================================================
-ConstRequestPtr Delivery::make(
-  const std::string& id,
+ConstRequestPtr Delivery::make(const std::string& id,
   std::size_t pickup_waypoint,
   std::string pickup_dispenser,
   std::size_t dropoff_waypoint,
   std::string dropoff_ingestor,
   std::vector<DispenserRequestItem> items,
-  std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-  std::shared_ptr<rmf_battery::DevicePowerSink> device_sink,
-  std::shared_ptr<rmf_traffic::agv::Planner> planner,
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+  rmf_battery::ConstDevicePowerSinkPtr device_sink,
+  std::shared_ptr<const rmf_traffic::agv::Planner> planner,
   rmf_traffic::Time start_time,
   bool drain_battery,
   ConstPriorityPtr priority)
@@ -357,13 +356,14 @@ ConstRequestPtr Delivery::make(
     dropoff_waypoint,
     dropoff_ingestor,
     items,
-    motion_sink,
-    device_sink,
-    planner,
+    std::move(motion_sink),
+    std::move(device_sink),
+    std::move(planner),
     start_time,
     drain_battery);
 
-  return std::make_shared<Request>(id, start_time, priority, description);
+  return std::make_shared<Request>(
+    id, start_time, std::move(priority), description);
 
 }
 

--- a/rmf_task/src/rmf_task/requests/Loop.cpp
+++ b/rmf_task/src/rmf_task/requests/Loop.cpp
@@ -31,9 +31,9 @@ public:
   std::size_t start_waypoint;
   std::size_t finish_waypoint;
   std::size_t num_loops;
-  std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink;
-  std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink;
-  std::shared_ptr<rmf_traffic::agv::Planner> planner;
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink;
+  rmf_battery::ConstDevicePowerSinkPtr ambient_sink;
+  std::shared_ptr<const rmf_traffic::agv::Planner> planner;
   rmf_traffic::Time start_time;
   bool drain_battery;
 
@@ -46,9 +46,9 @@ DescriptionPtr LoopDescription::make(
   std::size_t start_waypoint,
   std::size_t finish_waypoint,
   std::size_t num_loops,
-  std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-  std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
-  std::shared_ptr<rmf_traffic::agv::Planner> planner,
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+  rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+  std::shared_ptr<const rmf_traffic::agv::Planner> planner,
   rmf_traffic::Time start_time,
   bool drain_battery)
 {
@@ -356,9 +356,9 @@ ConstRequestPtr Loop::make(
   std::size_t start_waypoint,
   std::size_t finish_waypoint,
   std::size_t num_loops,
-  std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-  std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
-  std::shared_ptr<rmf_traffic::agv::Planner> planner,
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+  rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+  std::shared_ptr<const rmf_traffic::agv::Planner> planner,
   rmf_traffic::Time start_time,
   bool drain_battery,
   ConstPriorityPtr priority)
@@ -367,13 +367,14 @@ ConstRequestPtr Loop::make(
     start_waypoint,
     finish_waypoint,
     num_loops,
-    motion_sink,
-    ambient_sink,
-    planner,
+    std::move(motion_sink),
+    std::move(ambient_sink),
+    std::move(planner),
     start_time,
     drain_battery);
 
-  return std::make_shared<Request>(id, start_time, priority, description);
+  return std::make_shared<Request>(
+    id, start_time, std::move(priority), description);
 
 }
 

--- a/rmf_task/test/unit/agv/test_TaskPlanner.cpp
+++ b/rmf_task/test/unit/agv/test_TaskPlanner.cpp
@@ -176,8 +176,8 @@ SCENARIO("Grid World")
   const auto cost_calculator =
     rmf_task::BinaryPriorityScheme::make_cost_calculator();
 
-  std::shared_ptr<TaskPlanner::Configuration> task_config =
-    std::make_shared<TaskPlanner::Configuration>(
+  TaskPlanner::Configuration task_config =
+    TaskPlanner::Configuration(
       battery_system,
       motion_sink,
       device_sink,


### PR DESCRIPTION
## Quality improvement

The API does not currently exercise const-correctness as effectively as it could. Many API signatures are asking for mutable objects when immutable objects would suffice.

This PR fixes that and tightens up some of the API details.

This PR depends on https://github.com/open-rmf/rmf_battery/pull/1