### PR TITLE
Modify id of request generated by ParkRobotFactory

### DIFF
--- a/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
@@ -67,7 +67,7 @@ ParkRobotFactory::ParkRobotFactory(
 ConstRequestPtr ParkRobotFactory::make_request(
   const agv::State& state) const
 {
-  std::string id = "ReturnToCharger" + generate_uuid();
+  std::string id = "ParkRobot" + generate_uuid();
   const auto start_waypoint = state.location().waypoint();
   const auto finish_waypoint = _pimpl->parking_waypoint.has_value() ?
     _pimpl->parking_waypoint.value() : state.charging_waypoint();


### PR DESCRIPTION
During the review of PR https://github.com/open-rmf/rmf_task/pull/28, `ReturnToChargerFactory` was renamed to `ParkRobotFactory`. But the id of the request generated by the factory was not updated.