### PR TITLE
Fix upload-artifact@v2 paths

### DIFF
--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -38,6 +38,6 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: colcon-test-logs
-          path: ${{ steps.tsan_build_test.outputs.ros-workspace-directory-name }}/log/latest_test/rmf_task/streams.log
+          path: ${{ steps.tsan_build_test.outputs.ros-workspace-directory-name }}/log
         if: always()
 


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## Bug fix

### Fixed bug

The github action upload-artifact@v2 finds the most common base directory and attempts to upload them. `latest_test` is a symlink so it fails when it needs to upload the `latest_test` directory. This just changes it to upload the whole log directory.

Reference: https://github.com/actions/upload-artifact