### PR TITLE
the CMake user package registry can do unexpected things.

### DIFF
--- a/rmf_task/CMakeLists.txt
+++ b/rmf_task/CMakeLists.txt
@@ -131,5 +131,3 @@ export(
   FILE ${CMAKE_CURRENT_BINARY_DIR}/rmf_task-targets.cmake
   NAMESPACE rmf_task::
 )
-
-export(PACKAGE rmf_task)


### PR DESCRIPTION
The CMake user package registry can cause unexpected behavior if people aren't accustomed to it. This PR removes the `export(PACKAGE ...)` invocation that adds to the user package registry in `~/.cmake/packages` during the `colcon` build/install process.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>