### PR TITLE
Use ament_cmake_uncrustify

### DIFF
--- a/rmf_task/CMakeLists.txt
+++ b/rmf_task/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(rmf_battery REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 find_package(ament_cmake_catch2 QUIET)
-find_package(rmf_cmake_uncrustify QUIET)
+find_package(ament_cmake_uncrustify QUIET)
 
 # ===== RMF Tasks library
 file(GLOB lib_srcs
@@ -52,7 +52,7 @@ target_include_directories(rmf_task
     ${EIGEN3_INCLUDE_DIRS}
 )
 
-if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND rmf_cmake_uncrustify_FOUND)
+if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND ament_cmake_uncrustify_FOUND)
   file(GLOB_RECURSE unit_test_srcs "test/*.cpp")
 
   ament_add_catch2(
@@ -73,7 +73,7 @@ if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND rmf_cmake_uncrustify_FOUND)
     NAMES "rmf_code_style.cfg"
     PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
-  rmf_uncrustify(
+  ament_uncrustify(
     ARGN include src test
     CONFIG_FILE ${uncrustify_config_file}
     MAX_LINE_LENGTH 80

--- a/rmf_task/package.xml
+++ b/rmf_task/package.xml
@@ -16,7 +16,7 @@
   <depend>eigen</depend>
 
   <test_depend>ament_cmake_catch2</test_depend>
-  <test_depend>rmf_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
We currently have the rmf_cmake_uncrustify package that is used for style checking with colcon test. The original reason for having this package and not using ament_cmake_uncrustify was that the latter did not support custom uncrustify configuration files. But this feature was [merged upstream](https://github.com/ament/ament_lint/pull/200) quite a while ago and has been part of `foxy` and `galactic` releases. Hence, switching back to `ament_cmake_uncrustify` for ease of maintenance and distribution.