### PR TITLE
Add find_package/find_dependency for vendored project.

### DIFF
--- a/rmf_task_sequence/CMakeLists.txt
+++ b/rmf_task_sequence/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(rmf_api_msgs REQUIRED)
 find_package(rmf_task REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(nlohmann_json_schema_validator_vendor REQUIRED)
+find_package(nlohmann_json_schema_validator REQUIRED)
 
 find_package(ament_cmake_catch2 QUIET)
 find_package(ament_cmake_uncrustify QUIET)

--- a/rmf_task_sequence/cmake/rmf_task_sequence-config.cmake.in
+++ b/rmf_task_sequence/cmake/rmf_task_sequence-config.cmake.in
@@ -7,6 +7,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(rmf_task)
 find_dependency(nlohmann_json)
 find_dependency(nlohmann_json_schema_validator_vendor)
+find_dependency(nlohmann_json_schema_validator)
 
 if(NOT TARGET rmf_task_sequence::rmf_task_sequence)
     include("${rmf_task_sequence_CMAKE_DIR}/rmf_task_sequence-targets.cmake")


### PR DESCRIPTION
The vendor package for nlohmann_json_schema_validator was previously exporting dependency info for that package, however that is not the recommended workflow for vendor packages which are ideally as transparent as possible.

This PR should be held until https://github.com/open-rmf/nlohmann_json_schema_validator_vendor/pull/10 is merged.