### PR TITLE
Add missing buildtool_depend on cmake

### DIFF
--- a/rmf_task/package.xml
+++ b/rmf_task/package.xml
@@ -10,6 +10,8 @@
   <author>Aaron</author>
   <author>Yadunund</author>
 
+  <buildtool_depend>cmake</buildtool_depend>
+
   <depend>rmf_battery</depend>
   <depend>rmf_utils</depend>
 

--- a/rmf_task_sequence/package.xml
+++ b/rmf_task_sequence/package.xml
@@ -9,6 +9,8 @@
   <license>Apache License 2.0</license>
   <author>Grey</author>
 
+  <buildtool_depend>cmake</buildtool_depend>
+
   <depend>rmf_api_msgs</depend>
   <depend>rmf_task</depend>
   <depend>nlohmann-json-dev</depend>


### PR DESCRIPTION
## Bug fix

### Fixed bug

These packages are missing buildtool dependencies. They're both declared as `cmake` packages, so they should declare a buildtool dependency on cmake to ensure that package is installed when building.

This missing dependency was discovered when building debs for Rolling packages with `-DBUILD_TESTING=OFF` and without test dependencies installed. It seems that once of those dependencies is indirectly ensuring that `cmake` is installed right now.

### Fix applied

Add `<buildtool_depend>cmake</buildtool_depend>` to the package manifests.