### PR TITLE
Fix build with Apple Clang

### DIFF
--- a/rmf_task/src/rmf_task/Log.cpp
+++ b/rmf_task/src/rmf_task/Log.cpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <list>
+#include <unordered_map>
 
 namespace rmf_task {
 


### PR DESCRIPTION
Building on macOS with Apple Clang as default compiler throws a build error due to a missing include for `unordered_map`. 