### PR TITLE
Port Add missing buildtool_depend on cmake (#75) into main

### DIFF
--- a/rmf_task/package.xml
+++ b/rmf_task/package.xml
@@ -10,6 +10,8 @@
   <author>Aaron</author>
   <author>Yadunund</author>
 
+  <buildtool_depend>cmake</buildtool_depend>
+
   <depend>rmf_battery</depend>
   <depend>rmf_utils</depend>
 

--- a/rmf_task_sequence/package.xml
+++ b/rmf_task_sequence/package.xml
@@ -9,6 +9,8 @@
   <license>Apache License 2.0</license>
   <author>Grey</author>
 
+  <buildtool_depend>cmake</buildtool_depend>
+
   <depend>rmf_api_msgs</depend>
   <depend>rmf_task</depend>
   <depend>nlohmann-json-dev</depend>


### PR DESCRIPTION
Port #75 into `main`.