### PR TITLE
Task request time and initiator in Booking

### DIFF
--- a/rmf_task/include/rmf_task/Request.hpp
+++ b/rmf_task/include/rmf_task/Request.hpp
@@ -44,8 +44,7 @@ public:
   ///
   /// \param[in] automatic
   ///   True if this request is auto-generated
-  //
-  // TODO(MXG): Deprecate this constructor?
+  [[deprecated]]
   Request(
     const std::string& id,
     rmf_traffic::Time earliest_start_time,

--- a/rmf_task/include/rmf_task/Request.hpp
+++ b/rmf_task/include/rmf_task/Request.hpp
@@ -44,7 +44,8 @@ public:
   ///
   /// \param[in] automatic
   ///   True if this request is auto-generated
-  [[deprecated]]
+  //
+  // TODO(MXG): Deprecate this constructor?
   Request(
     const std::string& id,
     rmf_traffic::Time earliest_start_time,

--- a/rmf_task/include/rmf_task/RequestFactory.hpp
+++ b/rmf_task/include/rmf_task/RequestFactory.hpp
@@ -34,6 +34,15 @@ public:
   /// \param[in] state
   ///   The state that the robot will have when it is ready to perform the
   ///   request.
+  [[deprecated]]
+  virtual ConstRequestPtr make_request(const State& state) const = 0;
+
+  /// Generate a request for the AGV given the state that the robot will have
+  /// when it is ready to perform the request.
+  ///
+  /// \param[in] state
+  ///   The state that the robot will have when it is ready to perform the
+  ///   request.
   ///
   /// \param[in] requester
   ///   The identifier of the entity that requested this task.

--- a/rmf_task/include/rmf_task/RequestFactory.hpp
+++ b/rmf_task/include/rmf_task/RequestFactory.hpp
@@ -29,9 +29,21 @@ class RequestFactory
 public:
 
   /// Generate a request for the AGV given the state that the robot will have
-  /// when it is ready to perform the request
+  /// when it is ready to perform the request.
+  ///
+  /// \param[in] state
+  ///   The state that the robot will have when it is ready to perform the
+  ///   request.
+  ///
+  /// \param[in] requester
+  ///   The identifier of the entity that requested this task.
+  ///
+  /// \param[in] time_now
+  ///   The current time.
   virtual ConstRequestPtr make_request(
-    const State& state) const = 0;
+    const State& state,
+    const std::string& requester,
+    rmf_traffic::Time time_now) const = 0;
 
   virtual ~RequestFactory() = default;
 };

--- a/rmf_task/include/rmf_task/RequestFactory.hpp
+++ b/rmf_task/include/rmf_task/RequestFactory.hpp
@@ -34,25 +34,7 @@ public:
   /// \param[in] state
   ///   The state that the robot will have when it is ready to perform the
   ///   request.
-  [[deprecated]]
   virtual ConstRequestPtr make_request(const State& state) const = 0;
-
-  /// Generate a request for the AGV given the state that the robot will have
-  /// when it is ready to perform the request.
-  ///
-  /// \param[in] state
-  ///   The state that the robot will have when it is ready to perform the
-  ///   request.
-  ///
-  /// \param[in] requester
-  ///   The identifier of the entity that requested this task.
-  ///
-  /// \param[in] time_now
-  ///   The current time.
-  virtual ConstRequestPtr make_request(
-    const State& state,
-    const std::string& requester,
-    rmf_traffic::Time time_now) const = 0;
 
   virtual ~RequestFactory() = default;
 };

--- a/rmf_task/include/rmf_task/Task.hpp
+++ b/rmf_task/include/rmf_task/Task.hpp
@@ -31,6 +31,7 @@
 #include <rmf_traffic/Time.hpp>
 
 #include <memory>
+#include <optional>
 #include <functional>
 
 namespace rmf_task {
@@ -67,69 +68,52 @@ public:
 
   /// Constructor
   ///
-  /// \param[in] id_
-  ///   The identity of the booking
+  /// \param[in] id
+  ///   The identity of the booking.
   ///
-  /// \param[in] earliest_start_time_
-  ///   The earliest time that the task may begin
+  /// \param[in] earliest_start_time
+  ///   The earliest time that the task may begin.
   ///
-  /// \param[in] priority_
-  ///   The priority of the booking
+  /// \param[in] priority
+  ///   The priority of the booking.
   ///
-  /// \param[in] automatic_
-  ///   Whether this booking was automatically generated
+  /// \param[in] automatic
+  ///   Whether this booking was automatically generated, default value as
+  ///   false.
   ///
-  /// TODO(AC): Deprecate this constructor
+  /// \param[in] requester
+  ///   The identifier of the entity that requested this task. This field is
+  ///   optional.
+  ///
+  /// \param[in] request_time
+  ///   The time that this task was booked. This field is optional.
   Booking(
-    std::string id_,
-    rmf_traffic::Time earliest_start_time_,
-    ConstPriorityPtr priority_,
-    bool automatic_ = false);
+    std::string id,
+    rmf_traffic::Time earliest_start_time,
+    ConstPriorityPtr priority,
+    bool automatic = false,
+    std::optional<std::string> requester = std::nullopt,
+    std::optional<rmf_traffic::Time> request_time = std::nullopt);
 
-  /// Constructor
-  ///
-  /// \param[in] id_
-  ///   The identity of the booking
-  ///
-  /// \param[in] earliest_start_time_
-  ///   The earliest time that the task may begin
-  ///
-  /// \param[in] request_time_
-  ///   The time that this task was booked
-  ///
-  /// \param[in] priority_
-  ///   The priority of the booking
-  ///
-  /// \param[in] requester_
-  ///   The identifier of the entity that requested this task
-  ///
-  /// \param[in] automatic_
-  ///   Whether this booking was automatically generated
-  Booking(
-    std::string id_,
-    rmf_traffic::Time earliest_start_time_,
-    rmf_traffic::Time request_time_,
-    ConstPriorityPtr priority_,
-    std::string requester_,
-    bool automatic_ = false);
-
-  /// The unique id for this booking
+  /// The unique id for this booking.
   const std::string& id() const;
 
-  /// Get the earliest time that this booking may begin
+  /// Get the earliest time that this booking may begin.
   rmf_traffic::Time earliest_start_time() const;
 
-  /// Get the time that this booking was requested
-  rmf_traffic::Time request_time() const;
-
-  /// Get the priority of this booking
+  /// Get the priority of this booking.
   ConstPriorityPtr priority() const;
 
-  /// Get the identifier of the entity that requested this booking
-  const std::string& requester() const;
-
-  // Returns true if this booking was automatically generated
+  // Returns true if this booking was automatically generated.
   bool automatic() const;
+
+  /// Get the identifier of the entity that requested this booking. Returns a
+  /// nullopt if no requester was defined.
+  std::optional<std::string> requester() const;
+
+  /// Get the time that this booking was requested. Returns a nullopt if no
+  /// request time was defined.
+  std::optional<rmf_traffic::Time> request_time() const;
 
   class Implementation;
 private:

--- a/rmf_task/include/rmf_task/Task.hpp
+++ b/rmf_task/include/rmf_task/Task.hpp
@@ -79,7 +79,7 @@ public:
   /// \param[in] automatic_
   ///   Whether this booking was automatically generated
   ///
-  /// TODO(AA): Deprecate this constructor
+  /// TODO(AC): Deprecate this constructor
   Booking(
     std::string id_,
     rmf_traffic::Time earliest_start_time_,

--- a/rmf_task/include/rmf_task/Task.hpp
+++ b/rmf_task/include/rmf_task/Task.hpp
@@ -78,10 +78,39 @@ public:
   ///
   /// \param[in] automatic_
   ///   Whether this booking was automatically generated
+  ///
+  /// TODO(AA): Deprecate this constructor
   Booking(
     std::string id_,
     rmf_traffic::Time earliest_start_time_,
     ConstPriorityPtr priority_,
+    bool automatic_ = false);
+
+  /// Constructor
+  ///
+  /// \param[in] id_
+  ///   The identity of the booking
+  ///
+  /// \param[in] earliest_start_time_
+  ///   The earliest time that the task may begin
+  ///
+  /// \param[in] request_time_
+  ///   The time that this task was booked
+  ///
+  /// \param[in] priority_
+  ///   The priority of the booking
+  ///
+  /// \param[in] initiator_
+  ///   The name of the entity that requested this task
+  ///
+  /// \param[in] automatic_
+  ///   Whether this booking was automatically generated
+  Booking(
+    std::string id_,
+    rmf_traffic::Time earliest_start_time_,
+    rmf_traffic::Time request_time_,
+    ConstPriorityPtr priority_,
+    std::string initiator_,
     bool automatic_ = false);
 
   /// The unique id for this booking
@@ -90,8 +119,14 @@ public:
   /// Get the earliest time that this booking may begin
   rmf_traffic::Time earliest_start_time() const;
 
+  /// Get the time that this booking was requested
+  rmf_traffic::Time request_time() const;
+
   /// Get the priority of this booking
   ConstPriorityPtr priority() const;
+
+  /// Get the name of the entity that requested this booking
+  const std::string& initiator() const;
 
   // Returns true if this booking was automatically generated
   bool automatic() const;

--- a/rmf_task/include/rmf_task/Task.hpp
+++ b/rmf_task/include/rmf_task/Task.hpp
@@ -68,22 +68,22 @@ public:
 
   /// Constructor
   ///
-  /// \param[in] id_
+  /// \param[in] id
   ///   The identity of the booking
   ///
-  /// \param[in] earliest_start_time_
+  /// \param[in] earliest_start_time
   ///   The earliest time that the task may begin
   ///
-  /// \param[in] priority_
+  /// \param[in] priority
   ///   The priority of the booking
   ///
-  /// \param[in] automatic_
+  /// \param[in] automatic
   ///   Whether this booking was automatically generated
   Booking(
-    std::string id_,
-    rmf_traffic::Time earliest_start_time_,
-    ConstPriorityPtr priority_,
-    bool automatic_ = false);
+    std::string id,
+    rmf_traffic::Time earliest_start_time,
+    ConstPriorityPtr priority,
+    bool automatic = false);
 
   /// Constructor
   ///

--- a/rmf_task/include/rmf_task/Task.hpp
+++ b/rmf_task/include/rmf_task/Task.hpp
@@ -68,6 +68,25 @@ public:
 
   /// Constructor
   ///
+  /// \param[in] id_
+  ///   The identity of the booking
+  ///
+  /// \param[in] earliest_start_time_
+  ///   The earliest time that the task may begin
+  ///
+  /// \param[in] priority_
+  ///   The priority of the booking
+  ///
+  /// \param[in] automatic_
+  ///   Whether this booking was automatically generated
+  Booking(
+    std::string id_,
+    rmf_traffic::Time earliest_start_time_,
+    ConstPriorityPtr priority_,
+    bool automatic_ = false);
+
+  /// Constructor
+  ///
   /// \param[in] id
   ///   The identity of the booking.
   ///
@@ -77,23 +96,23 @@ public:
   /// \param[in] priority
   ///   The priority of the booking.
   ///
-  /// \param[in] automatic
-  ///   Whether this booking was automatically generated, default value as
-  ///   false.
-  ///
   /// \param[in] requester
   ///   The identifier of the entity that requested this task. This field is
   ///   optional.
   ///
   /// \param[in] request_time
   ///   The time that this task was booked. This field is optional.
+  ///
+  /// \param[in] automatic
+  ///   Whether this booking was automatically generated, default value as
+  ///   false.
   Booking(
     std::string id,
     rmf_traffic::Time earliest_start_time,
     ConstPriorityPtr priority,
-    bool automatic = false,
-    std::optional<std::string> requester = std::nullopt,
-    std::optional<rmf_traffic::Time> request_time = std::nullopt);
+    std::optional<std::string> requester,
+    std::optional<rmf_traffic::Time> request_time,
+    bool automatic = false);
 
   /// The unique id for this booking.
   const std::string& id() const;
@@ -104,9 +123,6 @@ public:
   /// Get the priority of this booking.
   ConstPriorityPtr priority() const;
 
-  // Returns true if this booking was automatically generated.
-  bool automatic() const;
-
   /// Get the identifier of the entity that requested this booking. Returns a
   /// nullopt if no requester was defined.
   std::optional<std::string> requester() const;
@@ -114,6 +130,9 @@ public:
   /// Get the time that this booking was requested. Returns a nullopt if no
   /// request time was defined.
   std::optional<rmf_traffic::Time> request_time() const;
+
+  // Returns true if this booking was automatically generated.
+  bool automatic() const;
 
   class Implementation;
 private:

--- a/rmf_task/include/rmf_task/Task.hpp
+++ b/rmf_task/include/rmf_task/Task.hpp
@@ -97,11 +97,10 @@ public:
   ///   The priority of the booking.
   ///
   /// \param[in] requester
-  ///   The identifier of the entity that requested this task. This field is
-  ///   optional.
+  ///   The identifier of the entity that requested this task.
   ///
   /// \param[in] request_time
-  ///   The time that this task was booked. This field is optional.
+  ///   The time that this task was booked.
   ///
   /// \param[in] automatic
   ///   Whether this booking was automatically generated, default value as
@@ -110,8 +109,8 @@ public:
     std::string id,
     rmf_traffic::Time earliest_start_time,
     ConstPriorityPtr priority,
-    std::optional<std::string> requester,
-    std::optional<rmf_traffic::Time> request_time,
+    const std::string& requester,
+    rmf_traffic::Time request_time,
     bool automatic = false);
 
   /// The unique id for this booking.

--- a/rmf_task/include/rmf_task/Task.hpp
+++ b/rmf_task/include/rmf_task/Task.hpp
@@ -100,8 +100,8 @@ public:
   /// \param[in] priority_
   ///   The priority of the booking
   ///
-  /// \param[in] initiator_
-  ///   The name of the entity that requested this task
+  /// \param[in] requester_
+  ///   The identifier of the entity that requested this task
   ///
   /// \param[in] automatic_
   ///   Whether this booking was automatically generated
@@ -110,7 +110,7 @@ public:
     rmf_traffic::Time earliest_start_time_,
     rmf_traffic::Time request_time_,
     ConstPriorityPtr priority_,
-    std::string initiator_,
+    std::string requester_,
     bool automatic_ = false);
 
   /// The unique id for this booking
@@ -125,8 +125,8 @@ public:
   /// Get the priority of this booking
   ConstPriorityPtr priority() const;
 
-  /// Get the name of the entity that requested this booking
-  const std::string& initiator() const;
+  /// Get the identifier of the entity that requested this booking
+  const std::string& requester() const;
 
   // Returns true if this booking was automatically generated
   bool automatic() const;

--- a/rmf_task/include/rmf_task/TaskPlanner.hpp
+++ b/rmf_task/include/rmf_task/TaskPlanner.hpp
@@ -200,20 +200,20 @@ public:
 
   /// Constructor
   ///
+  /// \param[in] planner_id
+  ///   Identifier of this task planner, to be used for booking automated
+  ///   requests.
+  ///
   /// \param[in] configuration
-  ///   The configuration for the planner
+  ///   The configuration for the planner.
   ///
   /// \param[in] default_options
   ///   Default options for the task planner to use when solving for assignments.
   ///   These options can be overriden each time a plan is requested.
-  ///
-  /// \param[in] task_planner_name
-  ///   Identifier of this task planner, to be used for booking automated
-  ///   requests.
   TaskPlanner(
+    const std::string& planner_id,
     Configuration configuration,
-    Options default_options,
-    const std::string& task_planner_name);
+    Options default_options);
 
   /// Get a const reference to configuration of this task planner
   const Configuration& configuration() const;

--- a/rmf_task/include/rmf_task/TaskPlanner.hpp
+++ b/rmf_task/include/rmf_task/TaskPlanner.hpp
@@ -198,6 +198,23 @@ public:
     Configuration configuration,
     Options default_options);
 
+  /// Constructor
+  ///
+  /// \param[in] configuration
+  ///   The configuration for the planner
+  ///
+  /// \param[in] default_options
+  ///   Default options for the task planner to use when solving for assignments.
+  ///   These options can be overriden each time a plan is requested.
+  ///
+  /// \param[in] task_planner_name
+  ///   Identifier of this task planner, to be used for booking automated
+  ///   requests.
+  TaskPlanner(
+    Configuration configuration,
+    Options default_options,
+    const std::string& task_planner_name);
+
   /// Get a const reference to configuration of this task planner
   const Configuration& configuration() const;
 

--- a/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
@@ -79,9 +79,35 @@ public:
   ///
   /// \param[in] automatic
   ///   True if this request is auto-generated
+  ///
+  /// TODO(AC): Deprecate this constructor
   static ConstRequestPtr make(
     rmf_traffic::Time earliest_start_time,
     ConstPriorityPtr priority = nullptr,
+    bool automatic = true);
+
+  /// Generate a chargebattery request
+  ///
+  /// \param[in] earliest_start_time
+  ///   The desired start time for this request
+  ///
+  /// \param[in] request_time
+  ///   The time this request was generated or submitted, to be part of the
+  ///   booking information
+  ///
+  /// \param[in] priority
+  ///   The priority for this request
+  ///
+  /// \param[in] initiator
+  ///   The entity that started this request
+  ///
+  /// \param[in] automatic
+  ///   True if this request is auto-generated
+  static ConstRequestPtr make(
+    rmf_traffic::Time earliest_start_time,
+    rmf_traffic::Time request_time,
+    ConstPriorityPtr priority = nullptr,
+    const std::string& initiator = "",
     bool automatic = true);
 };
 

--- a/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
@@ -98,7 +98,7 @@ public:
   /// \param[in] priority
   ///   The priority for this request
   ///
-  /// \param[in] initiator
+  /// \param[in] requester
   ///   The entity that started this request
   ///
   /// \param[in] automatic
@@ -107,7 +107,7 @@ public:
     rmf_traffic::Time earliest_start_time,
     rmf_traffic::Time request_time,
     ConstPriorityPtr priority = nullptr,
-    const std::string& initiator = "",
+    const std::string& requester = "",
     bool automatic = true);
 };
 

--- a/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
@@ -90,7 +90,7 @@ public:
   ///   The desired start time for this request.
   ///
   /// \param[in] requester
-  ///   The entity that started this request.
+  ///   The entity that issued this request.
   ///
   /// \param[in] request_time
   ///   The time this request was generated or submitted.

--- a/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
@@ -69,46 +69,29 @@ public:
     rmf_utils::impl_ptr<Implementation> _pimpl;
   };
 
-  /// Generate a chargebattery request
+  /// Generate a chargebattery request.
   ///
   /// \param[in] earliest_start_time
-  ///   The desired start time for this request
+  ///   The desired start time for this request.
   ///
   /// \param[in] priority
-  ///   The priority for this request
+  ///   The priority for this request.
   ///
   /// \param[in] automatic
-  ///   True if this request is auto-generated
+  ///   True if this request is auto-generated, default value as true.
   ///
-  /// TODO(AC): Deprecate this constructor
-  static ConstRequestPtr make(
-    rmf_traffic::Time earliest_start_time,
-    ConstPriorityPtr priority = nullptr,
-    bool automatic = true);
-
-  /// Generate a chargebattery request
-  ///
-  /// \param[in] earliest_start_time
-  ///   The desired start time for this request
+  /// \param[in] requester
+  ///   The entity that started this request. This field is optional.
   ///
   /// \param[in] request_time
   ///   The time this request was generated or submitted, to be part of the
-  ///   booking information
-  ///
-  /// \param[in] priority
-  ///   The priority for this request
-  ///
-  /// \param[in] requester
-  ///   The entity that started this request
-  ///
-  /// \param[in] automatic
-  ///   True if this request is auto-generated
+  ///   booking information. This field is optional.
   static ConstRequestPtr make(
     rmf_traffic::Time earliest_start_time,
-    rmf_traffic::Time request_time,
     ConstPriorityPtr priority = nullptr,
-    const std::string& requester = "",
-    bool automatic = true);
+    bool automatic = true,
+    std::optional<std::string> requester = std::nullopt,
+    std::optional<rmf_traffic::Time> request_time = std::nullopt);
 };
 
 } // namespace requests

--- a/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
@@ -69,29 +69,43 @@ public:
     rmf_utils::impl_ptr<Implementation> _pimpl;
   };
 
+  /// Generate a chargebattery request
+  ///
+  /// \param[in] earliest_start_time
+  ///   The desired start time for this request
+  ///
+  /// \param[in] priority
+  ///   The priority for this request
+  ///
+  /// \param[in] automatic
+  ///   True if this request is auto-generated
+  static ConstRequestPtr make(
+    rmf_traffic::Time earliest_start_time,
+    ConstPriorityPtr priority = nullptr,
+    bool automatic = true);
+
   /// Generate a chargebattery request.
   ///
   /// \param[in] earliest_start_time
   ///   The desired start time for this request.
+  ///
+  /// \param[in] requester
+  ///   The entity that started this request.
+  ///
+  /// \param[in] request_time
+  ///   The time this request was generated or submitted.
   ///
   /// \param[in] priority
   ///   The priority for this request.
   ///
   /// \param[in] automatic
   ///   True if this request is auto-generated, default value as true.
-  ///
-  /// \param[in] requester
-  ///   The entity that started this request. This field is optional.
-  ///
-  /// \param[in] request_time
-  ///   The time this request was generated or submitted, to be part of the
-  ///   booking information. This field is optional.
   static ConstRequestPtr make(
     rmf_traffic::Time earliest_start_time,
+    const std::string& requester,
+    rmf_traffic::Time request_time,
     ConstPriorityPtr priority = nullptr,
-    bool automatic = true,
-    std::optional<std::string> requester = std::nullopt,
-    std::optional<rmf_traffic::Time> request_time = std::nullopt);
+    bool automatic = true);
 };
 
 } // namespace requests

--- a/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
@@ -18,11 +18,13 @@
 #ifndef RMF_TASK__REQUESTS__FACTORY__CHARGEBATTERYFACTORY_HPP
 #define RMF_TASK__REQUESTS__FACTORY__CHARGEBATTERYFACTORY_HPP
 
+#include <functional>
 #include <optional>
 #include <string>
 
 #include <rmf_task/RequestFactory.hpp>
 #include <rmf_task/State.hpp>
+#include <rmf_traffic/Time.hpp>
 
 #include <rmf_utils/impl_ptr.hpp>
 
@@ -47,7 +49,12 @@ public:
   /// \param[in] requester
   ///   The identifier of the entity that owns this RequestFactory, that will be
   ///   the designated requester of each new request.
-  explicit ChargeBatteryFactory(const std::string& requester);
+  ///
+  /// \param[in] time_now_cb
+  ///   Callback function that returns the current time.
+  explicit ChargeBatteryFactory(
+    const std::string& requester,
+    std::function<rmf_traffic::Time()> time_now_cb);
 
   /// Documentation inherited
   ConstRequestPtr make_request(const State& state) const final;

--- a/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
@@ -18,6 +18,9 @@
 #ifndef RMF_TASK__REQUESTS__FACTORY__CHARGEBATTERYFACTORY_HPP
 #define RMF_TASK__REQUESTS__FACTORY__CHARGEBATTERYFACTORY_HPP
 
+#include <optional>
+#include <string>
+
 #include <rmf_task/RequestFactory.hpp>
 #include <rmf_task/State.hpp>
 
@@ -35,9 +38,7 @@ class ChargeBatteryFactory : public RequestFactory
 {
 public:
 
-  ChargeBatteryFactory();
-
-  ChargeBatteryFactory(const std::string& requester);
+  ChargeBatteryFactory(std::optional<std::string> requester = std::nullopt);
 
   /// Documentation inherited
   ConstRequestPtr make_request(

--- a/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
@@ -33,22 +33,18 @@ namespace requests {
 /// The ChargeBatteryFactory will generate a ChargeBattery request which
 /// requires an AGV to return to its desginated charging_waypoint as specified
 /// in its agv::State and wait till its battery charges up to the recharge_soc
-/// confugred in agv::Constraints recharge_soc specified in its agv::Constraints
+/// configured in agv::Constraints recharge_soc specified in its
+/// agv::Constraints
 class ChargeBatteryFactory : public RequestFactory
 {
 public:
 
   ChargeBatteryFactory();
 
-  /// Documentation inherited
-  [[deprecated]]
-  ConstRequestPtr make_request(const State& state) const final;
+  explicit ChargeBatteryFactory(const std::string& requester);
 
   /// Documentation inherited
-  ConstRequestPtr make_request(
-    const State& state,
-    const std::string& requester,
-    rmf_traffic::Time time_now) const final;
+  ConstRequestPtr make_request(const State& state) const final;
 
   class Implementation;
 

--- a/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
@@ -41,6 +41,10 @@ public:
   ChargeBatteryFactory();
 
   /// Documentation inherited
+  [[deprecated]]
+  ConstRequestPtr make_request(const State& state) const final;
+
+  /// Documentation inherited
   ConstRequestPtr make_request(
     const State& state,
     const std::string& requester,

--- a/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
@@ -39,8 +39,14 @@ class ChargeBatteryFactory : public RequestFactory
 {
 public:
 
+  /// Constructor
   ChargeBatteryFactory();
 
+  /// Constructor
+  ///
+  /// \param[in] requester
+  ///   The identifier of the entity that owns this RequestFactory, that will be
+  ///   the designated requester of each new request.
   explicit ChargeBatteryFactory(const std::string& requester);
 
   /// Documentation inherited

--- a/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
@@ -37,6 +37,8 @@ public:
 
   ChargeBatteryFactory();
 
+  ChargeBatteryFactory(const std::string& requester);
+
   /// Documentation inherited
   ConstRequestPtr make_request(
     const State& state) const final;

--- a/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
@@ -38,11 +38,13 @@ class ChargeBatteryFactory : public RequestFactory
 {
 public:
 
-  ChargeBatteryFactory(std::optional<std::string> requester = std::nullopt);
+  ChargeBatteryFactory();
 
   /// Documentation inherited
   ConstRequestPtr make_request(
-    const State& state) const final;
+    const State& state,
+    const std::string& requester,
+    rmf_traffic::Time time_now) const final;
 
   class Implementation;
 

--- a/rmf_task/include/rmf_task/requests/Clean.hpp
+++ b/rmf_task/include/rmf_task/requests/Clean.hpp
@@ -135,7 +135,7 @@ public:
   ///   The desired start time for this request.
   ///
   /// \param[in] requester
-  ///   The entity that started this request.
+  ///   The entity that issued this request.
   ///
   /// \param[in] request_time
   ///   The time this request was generated or submitted.

--- a/rmf_task/include/rmf_task/requests/Clean.hpp
+++ b/rmf_task/include/rmf_task/requests/Clean.hpp
@@ -104,6 +104,8 @@ public:
   ///
   /// \param[in] automatic
   ///   True if this request is auto-generated
+  ///
+  /// TODO(AC): Deprecate this constructor
   static ConstRequestPtr make(
     std::size_t start_waypoint,
     std::size_t end_waypoint,
@@ -111,6 +113,50 @@ public:
     const std::string& id,
     rmf_traffic::Time earliest_start_time,
     ConstPriorityPtr priority = nullptr,
+    bool automatic = false);
+
+  /// Generate a clean request
+  ///
+  /// \param[in] start_waypoint
+  ///   The graph index for the location where the AGV should begin its cleaning
+  ///   operation
+  ///
+  /// \param[in] end_waypoint
+  ///   The graph index for the location where the AGV ends up after its cleaning
+  ///   operation
+  ///
+  /// \param[in] cleaning_path
+  ///   A trajectory that describes the motion of the AGV during the cleaning
+  ///   operation. This is used to determine the process duration and expected
+  ///   battery drain
+  ///
+  /// \param[in] id
+  ///   A unique id for this request
+  ///
+  /// \param[in] earliest_start_time
+  ///   The desired start time for this request
+  ///
+  /// \param[in] request_time
+  ///   The time this request was generated or submitted, to be part of the
+  ///   booking information
+  ///
+  /// \param[in] priority
+  ///   The priority for this request
+  ///
+  /// \param[in] requester
+  ///   The entity that started this request
+  ///
+  /// \param[in] automatic
+  ///   True if this request is auto-generated
+  static ConstRequestPtr make(
+    std::size_t start_waypoint,
+    std::size_t end_waypoint,
+    const rmf_traffic::Trajectory& cleaning_path,
+    const std::string& id,
+    rmf_traffic::Time earliest_start_time,
+    rmf_traffic::Time request_time,
+    ConstPriorityPtr priority = nullptr,
+    const std::string& requester = "",
     bool automatic = false);
 };
 

--- a/rmf_task/include/rmf_task/requests/Clean.hpp
+++ b/rmf_task/include/rmf_task/requests/Clean.hpp
@@ -78,86 +78,49 @@ public:
     rmf_utils::impl_ptr<Implementation> _pimpl;
   };
 
-  /// Generate a clean request
+  /// Generate a clean request.
   ///
   /// \param[in] start_waypoint
   ///   The graph index for the location where the AGV should begin its cleaning
-  ///   operation
+  ///   operation.
   ///
   /// \param[in] end_waypoint
   ///   The graph index for the location where the AGV ends up after its cleaning
-  ///   operation
+  ///   operation.
   ///
   /// \param[in] cleaning_path
   ///   A trajectory that describes the motion of the AGV during the cleaning
   ///   operation. This is used to determine the process duration and expected
-  ///   battery drain
+  ///   battery drain.
   ///
   /// \param[in] id
-  ///   A unique id for this request
+  ///   A unique id for this request.
   ///
   /// \param[in] earliest_start_time
-  ///   The desired start time for this request
+  ///   The desired start time for this request.
   ///
   /// \param[in] priority
-  ///   The priority for this request
+  ///   The priority for this request.
   ///
   /// \param[in] automatic
-  ///   True if this request is auto-generated
+  ///   True if this request is auto-generated, default value as false.
   ///
-  /// TODO(AC): Deprecate this constructor
-  static ConstRequestPtr make(
-    std::size_t start_waypoint,
-    std::size_t end_waypoint,
-    const rmf_traffic::Trajectory& cleaning_path,
-    const std::string& id,
-    rmf_traffic::Time earliest_start_time,
-    ConstPriorityPtr priority = nullptr,
-    bool automatic = false);
-
-  /// Generate a clean request
-  ///
-  /// \param[in] start_waypoint
-  ///   The graph index for the location where the AGV should begin its cleaning
-  ///   operation
-  ///
-  /// \param[in] end_waypoint
-  ///   The graph index for the location where the AGV ends up after its cleaning
-  ///   operation
-  ///
-  /// \param[in] cleaning_path
-  ///   A trajectory that describes the motion of the AGV during the cleaning
-  ///   operation. This is used to determine the process duration and expected
-  ///   battery drain
-  ///
-  /// \param[in] id
-  ///   A unique id for this request
-  ///
-  /// \param[in] earliest_start_time
-  ///   The desired start time for this request
+  /// \param[in] requester
+  ///   The entity that started this request. This field is optional.
   ///
   /// \param[in] request_time
   ///   The time this request was generated or submitted, to be part of the
-  ///   booking information
-  ///
-  /// \param[in] priority
-  ///   The priority for this request
-  ///
-  /// \param[in] requester
-  ///   The entity that started this request
-  ///
-  /// \param[in] automatic
-  ///   True if this request is auto-generated
+  ///   booking information. This field is optional.
   static ConstRequestPtr make(
     std::size_t start_waypoint,
     std::size_t end_waypoint,
     const rmf_traffic::Trajectory& cleaning_path,
     const std::string& id,
     rmf_traffic::Time earliest_start_time,
-    rmf_traffic::Time request_time,
     ConstPriorityPtr priority = nullptr,
-    const std::string& requester = "",
-    bool automatic = false);
+    bool automatic = false,
+    std::optional<std::string> requester = std::nullopt,
+    std::optional<rmf_traffic::Time> request_time = std::nullopt);
 };
 
 } // namespace requests

--- a/rmf_task/include/rmf_task/requests/Clean.hpp
+++ b/rmf_task/include/rmf_task/requests/Clean.hpp
@@ -78,6 +78,41 @@ public:
     rmf_utils::impl_ptr<Implementation> _pimpl;
   };
 
+  /// Generate a clean request
+  ///
+  /// \param[in] start_waypoint
+  ///   The graph index for the location where the AGV should begin its cleaning
+  ///   operation
+  ///
+  /// \param[in] end_waypoint
+  ///   The graph index for the location where the AGV ends up after its cleaning
+  ///   operation
+  ///
+  /// \param[in] cleaning_path
+  ///   A trajectory that describes the motion of the AGV during the cleaning
+  ///   operation. This is used to determine the process duration and expected
+  ///   battery drain
+  ///
+  /// \param[in] id
+  ///   A unique id for this request
+  ///
+  /// \param[in] earliest_start_time
+  ///   The desired start time for this request
+  ///
+  /// \param[in] priority
+  ///   The priority for this request
+  ///
+  /// \param[in] automatic
+  ///   True if this request is auto-generated
+  static ConstRequestPtr make(
+    std::size_t start_waypoint,
+    std::size_t end_waypoint,
+    const rmf_traffic::Trajectory& cleaning_path,
+    const std::string& id,
+    rmf_traffic::Time earliest_start_time,
+    ConstPriorityPtr priority = nullptr,
+    bool automatic = false);
+
   /// Generate a clean request.
   ///
   /// \param[in] start_waypoint
@@ -99,28 +134,27 @@ public:
   /// \param[in] earliest_start_time
   ///   The desired start time for this request.
   ///
+  /// \param[in] requester
+  ///   The entity that started this request.
+  ///
+  /// \param[in] request_time
+  ///   The time this request was generated or submitted.
+  ///
   /// \param[in] priority
   ///   The priority for this request.
   ///
   /// \param[in] automatic
   ///   True if this request is auto-generated, default value as false.
-  ///
-  /// \param[in] requester
-  ///   The entity that started this request. This field is optional.
-  ///
-  /// \param[in] request_time
-  ///   The time this request was generated or submitted, to be part of the
-  ///   booking information. This field is optional.
   static ConstRequestPtr make(
     std::size_t start_waypoint,
     std::size_t end_waypoint,
     const rmf_traffic::Trajectory& cleaning_path,
     const std::string& id,
     rmf_traffic::Time earliest_start_time,
+    const std::string& requester,
+    rmf_traffic::Time request_time,
     ConstPriorityPtr priority = nullptr,
-    bool automatic = false,
-    std::optional<std::string> requester = std::nullopt,
-    std::optional<rmf_traffic::Time> request_time = std::nullopt);
+    bool automatic = false);
 };
 
 } // namespace requests

--- a/rmf_task/include/rmf_task/requests/Delivery.hpp
+++ b/rmf_task/include/rmf_task/requests/Delivery.hpp
@@ -99,82 +99,48 @@ public:
     rmf_utils::impl_ptr<Implementation> _pimpl;
   };
 
-  /// Generate a delivery request
+  /// Generate a delivery request.
   ///
   /// \param[in] pickup_waypoint
-  ///   The graph index for the pickup location
+  ///   The graph index for the pickup location.
   ///
   /// \param[in] pickup_wait
   ///   The expected duration the AGV has to wait at the pickup location for
-  ///   the items to be loaded
+  ///   the items to be loaded.
   ///
   /// \param[in] dropoff_waypoint
-  ///   The graph index for the dropoff location
+  ///   The graph index for the dropoff location.
   ///
   /// \param[in] dropoff_wait
   ///   The expected duration the AGV has to wait at the dropoff location for
-  ///   the items to be unloaded
+  ///   the items to be unloaded.
   ///
   /// \param[in] id
-  ///   A unique id for this request
+  ///   A unique id for this request.
   ///
   /// \param[in] earliest_start_time
-  ///   The desired start time for this request
+  ///   The desired start time for this request.
   ///
   /// \param[in] priority
-  ///   The priority for this request
+  ///   The priority for this request.
   ///
   /// \param[in] automatic
-  ///   True if this request is auto-generated
+  ///   True if this request is auto-generated, default value as false.
   ///
-  /// TODO(AC): Deprecate this constructor
-  static ConstRequestPtr make(
-    std::size_t pickup_waypoint,
-    rmf_traffic::Duration pickup_wait,
-    std::size_t dropoff_waypoint,
-    rmf_traffic::Duration dropoff_wait,
-    Payload payload,
-    const std::string& id,
-    rmf_traffic::Time earliest_start_time,
-    ConstPriorityPtr priority = nullptr,
-    bool automatic = false,
-    std::string pickup_from_dispenser = "",
-    std::string dropoff_to_ingestor = "");
-
-  /// Generate a delivery request
+  /// \param[in] pickup_from_dispenser
+  ///   The name of the dispenser to pick up the delivery item from, at the
+  ///   designated pickup waypoint. This field is optional.
   ///
-  /// \param[in] pickup_waypoint
-  ///   The graph index for the pickup location
+  /// \param[in] dropoff_to_ingestor
+  ///   The name of the ingestor to drop off the delivery item to, at the
+  ///   designated dropoff waypoint. This field is optional.
   ///
-  /// \param[in] pickup_wait
-  ///   The expected duration the AGV has to wait at the pickup location for
-  ///   the items to be loaded
-  ///
-  /// \param[in] dropoff_waypoint
-  ///   The graph index for the dropoff location
-  ///
-  /// \param[in] dropoff_wait
-  ///   The expected duration the AGV has to wait at the dropoff location for
-  ///   the items to be unloaded
-  ///
-  /// \param[in] id
-  ///   A unique id for this request
-  ///
-  /// \param[in] earliest_start_time
-  ///   The desired start time for this request
+  /// \param[in] requester
+  ///   The entity that started this request. This field is optional.
   ///
   /// \param[in] request_time
   ///   The time this request was generated or submitted, to be part of the
-  ///   booking information
-  ///
-  /// \param[in] priority
-  ///   The priority for this request
-  ///
-  /// \param[in] requester
-  ///   The entity that started this request
-  ///
-  /// \param[in] automatic
-  ///   True if this request is auto-generated
+  ///   booking information. This field is optional.
   static ConstRequestPtr make(
     std::size_t pickup_waypoint,
     rmf_traffic::Duration pickup_wait,
@@ -183,12 +149,12 @@ public:
     Payload payload,
     const std::string& id,
     rmf_traffic::Time earliest_start_time,
-    rmf_traffic::Time request_time,
     ConstPriorityPtr priority = nullptr,
-    const std::string& requester = "",
     bool automatic = false,
     std::string pickup_from_dispenser = "",
-    std::string dropoff_to_ingestor = "");
+    std::string dropoff_to_ingestor = "",
+    std::optional<std::string> requester = std::nullopt,
+    std::optional<rmf_traffic::Time> request_time = std::nullopt);
 };
 
 } // namespace requests

--- a/rmf_task/include/rmf_task/requests/Delivery.hpp
+++ b/rmf_task/include/rmf_task/requests/Delivery.hpp
@@ -126,6 +126,8 @@ public:
   ///
   /// \param[in] automatic
   ///   True if this request is auto-generated
+  ///
+  /// TODO(AC): Deprecate this constructor
   static ConstRequestPtr make(
     std::size_t pickup_waypoint,
     rmf_traffic::Duration pickup_wait,
@@ -135,6 +137,55 @@ public:
     const std::string& id,
     rmf_traffic::Time earliest_start_time,
     ConstPriorityPtr priority = nullptr,
+    bool automatic = false,
+    std::string pickup_from_dispenser = "",
+    std::string dropoff_to_ingestor = "");
+
+  /// Generate a delivery request
+  ///
+  /// \param[in] pickup_waypoint
+  ///   The graph index for the pickup location
+  ///
+  /// \param[in] pickup_wait
+  ///   The expected duration the AGV has to wait at the pickup location for
+  ///   the items to be loaded
+  ///
+  /// \param[in] dropoff_waypoint
+  ///   The graph index for the dropoff location
+  ///
+  /// \param[in] dropoff_wait
+  ///   The expected duration the AGV has to wait at the dropoff location for
+  ///   the items to be unloaded
+  ///
+  /// \param[in] id
+  ///   A unique id for this request
+  ///
+  /// \param[in] earliest_start_time
+  ///   The desired start time for this request
+  ///
+  /// \param[in] request_time
+  ///   The time this request was generated or submitted, to be part of the
+  ///   booking information
+  ///
+  /// \param[in] priority
+  ///   The priority for this request
+  ///
+  /// \param[in] requester
+  ///   The entity that started this request
+  ///
+  /// \param[in] automatic
+  ///   True if this request is auto-generated
+  static ConstRequestPtr make(
+    std::size_t pickup_waypoint,
+    rmf_traffic::Duration pickup_wait,
+    std::size_t dropoff_waypoint,
+    rmf_traffic::Duration dropoff_wait,
+    Payload payload,
+    const std::string& id,
+    rmf_traffic::Time earliest_start_time,
+    rmf_traffic::Time request_time,
+    ConstPriorityPtr priority = nullptr,
+    const std::string& requester = "",
     bool automatic = false,
     std::string pickup_from_dispenser = "",
     std::string dropoff_to_ingestor = "");

--- a/rmf_task/include/rmf_task/requests/Delivery.hpp
+++ b/rmf_task/include/rmf_task/requests/Delivery.hpp
@@ -99,6 +99,46 @@ public:
     rmf_utils::impl_ptr<Implementation> _pimpl;
   };
 
+  /// Generate a delivery request
+  ///
+  /// \param[in] pickup_waypoint
+  ///   The graph index for the pickup location
+  ///
+  /// \param[in] pickup_wait
+  ///   The expected duration the AGV has to wait at the pickup location for
+  ///   the items to be loaded
+  ///
+  /// \param[in] dropoff_waypoint
+  ///   The graph index for the dropoff location
+  ///
+  /// \param[in] dropoff_wait
+  ///   The expected duration the AGV has to wait at the dropoff location for
+  ///   the items to be unloaded
+  ///
+  /// \param[in] id
+  ///   A unique id for this request
+  ///
+  /// \param[in] earliest_start_time
+  ///   The desired start time for this request
+  ///
+  /// \param[in] priority
+  ///   The priority for this request
+  ///
+  /// \param[in] automatic
+  ///   True if this request is auto-generated
+  static ConstRequestPtr make(
+    std::size_t pickup_waypoint,
+    rmf_traffic::Duration pickup_wait,
+    std::size_t dropoff_waypoint,
+    rmf_traffic::Duration dropoff_wait,
+    Payload payload,
+    const std::string& id,
+    rmf_traffic::Time earliest_start_time,
+    ConstPriorityPtr priority = nullptr,
+    bool automatic = false,
+    std::string pickup_from_dispenser = "",
+    std::string dropoff_to_ingestor = "");
+
   /// Generate a delivery request.
   ///
   /// \param[in] pickup_waypoint
@@ -121,6 +161,12 @@ public:
   /// \param[in] earliest_start_time
   ///   The desired start time for this request.
   ///
+  /// \param[in] requester
+  ///   The entity that started this request.
+  ///
+  /// \param[in] request_time
+  ///   The time this request was generated or submitted.
+  ///
   /// \param[in] priority
   ///   The priority for this request.
   ///
@@ -134,13 +180,6 @@ public:
   /// \param[in] dropoff_to_ingestor
   ///   The name of the ingestor to drop off the delivery item to, at the
   ///   designated dropoff waypoint. This field is optional.
-  ///
-  /// \param[in] requester
-  ///   The entity that started this request. This field is optional.
-  ///
-  /// \param[in] request_time
-  ///   The time this request was generated or submitted, to be part of the
-  ///   booking information. This field is optional.
   static ConstRequestPtr make(
     std::size_t pickup_waypoint,
     rmf_traffic::Duration pickup_wait,
@@ -149,12 +188,12 @@ public:
     Payload payload,
     const std::string& id,
     rmf_traffic::Time earliest_start_time,
+    const std::string& requester,
+    rmf_traffic::Time request_time,
     ConstPriorityPtr priority = nullptr,
     bool automatic = false,
     std::string pickup_from_dispenser = "",
-    std::string dropoff_to_ingestor = "",
-    std::optional<std::string> requester = std::nullopt,
-    std::optional<rmf_traffic::Time> request_time = std::nullopt);
+    std::string dropoff_to_ingestor = "");
 };
 
 } // namespace requests

--- a/rmf_task/include/rmf_task/requests/Delivery.hpp
+++ b/rmf_task/include/rmf_task/requests/Delivery.hpp
@@ -162,7 +162,7 @@ public:
   ///   The desired start time for this request.
   ///
   /// \param[in] requester
-  ///   The entity that started this request.
+  ///   The entity that issued this request.
   ///
   /// \param[in] request_time
   ///   The time this request was generated or submitted.

--- a/rmf_task/include/rmf_task/requests/Loop.hpp
+++ b/rmf_task/include/rmf_task/requests/Loop.hpp
@@ -142,7 +142,7 @@ public:
   /// \param[in] priority
   ///   The priority for this request
   ///
-  /// \param[in] initiator
+  /// \param[in] requester
   ///   The entity that started this request
   ///
   /// \param[in] automatic
@@ -155,7 +155,7 @@ public:
     rmf_traffic::Time earliest_start_time,
     rmf_traffic::Time request_time,
     ConstPriorityPtr priority = nullptr,
-    const std::string& initiator = "",
+    const std::string& requester = "",
     bool automatic = false);
 };
 

--- a/rmf_task/include/rmf_task/requests/Loop.hpp
+++ b/rmf_task/include/rmf_task/requests/Loop.hpp
@@ -106,6 +106,8 @@ public:
   ///
   /// \param[in] automatic
   ///   True if this request is auto-generated
+  ///
+  /// TODO(AC): Deprecate this constructor
   static ConstRequestPtr make(
     std::size_t start_waypoint,
     std::size_t finish_waypoint,
@@ -113,6 +115,47 @@ public:
     const std::string& id,
     rmf_traffic::Time earliest_start_time,
     ConstPriorityPtr priority = nullptr,
+    bool automatic = false);
+
+  /// Generate a loop request
+  ///
+  /// \param[in] start_waypoint
+  ///   The graph index for the starting waypoint of the loop
+  ///
+  /// \param[in] finish_waypoint
+  ///   The graph index for the finishing waypoint of the loop
+  ///
+  /// \param[in] num_loops
+  ///   The number of times the AGV should loop between the start_waypoint and
+  ///   finish_waypoint
+  ///
+  /// \param[in] id
+  ///   A unique id for this request
+  ///
+  /// \param[in] earliest_start_time
+  ///   The desired start time for this request
+  ///
+  /// \param[in] request_time
+  ///   The time this request was generated or submitted, to be part of the
+  ///   booking information
+  ///
+  /// \param[in] priority
+  ///   The priority for this request
+  ///
+  /// \param[in] initiator
+  ///   The entity that started this request
+  ///
+  /// \param[in] automatic
+  ///   True if this request is auto-generated
+  static ConstRequestPtr make(
+    std::size_t start_waypoint,
+    std::size_t finish_waypoint,
+    std::size_t num_loops,
+    const std::string& id,
+    rmf_traffic::Time earliest_start_time,
+    rmf_traffic::Time request_time,
+    ConstPriorityPtr priority = nullptr,
+    const std::string& initiator = "",
     bool automatic = false);
 };
 

--- a/rmf_task/include/rmf_task/requests/Loop.hpp
+++ b/rmf_task/include/rmf_task/requests/Loop.hpp
@@ -134,7 +134,7 @@ public:
   ///   The desired start time for this request.
   ///
   /// \param[in] requester
-  ///   The entity that started this request. This field is optional.
+  ///   The entity that issued this request.
   ///
   /// \param[in] request_time
   ///   The time this request was generated or submitted.

--- a/rmf_task/include/rmf_task/requests/Loop.hpp
+++ b/rmf_task/include/rmf_task/requests/Loop.hpp
@@ -83,80 +83,46 @@ public:
     rmf_utils::impl_ptr<Implementation> _pimpl;
   };
 
-  /// Generate a loop request
+  /// Generate a loop request.
   ///
   /// \param[in] start_waypoint
-  ///   The graph index for the starting waypoint of the loop
+  ///   The graph index for the starting waypoint of the loop.
   ///
   /// \param[in] finish_waypoint
-  ///   The graph index for the finishing waypoint of the loop
+  ///   The graph index for the finishing waypoint of the loop.
   ///
   /// \param[in] num_loops
   ///   The number of times the AGV should loop between the start_waypoint and
-  ///   finish_waypoint
+  ///   finish_waypoint.
   ///
   /// \param[in] id
-  ///   A unique id for this request
+  ///   A unique id for this request.
   ///
   /// \param[in] earliest_start_time
-  ///   The desired start time for this request
+  ///   The desired start time for this request.
   ///
   /// \param[in] priority
-  ///   The priority for this request
+  ///   The priority for this request.
   ///
   /// \param[in] automatic
-  ///   True if this request is auto-generated
+  ///   True if this request is auto-generated, default as false.
   ///
-  /// TODO(AC): Deprecate this constructor
-  static ConstRequestPtr make(
-    std::size_t start_waypoint,
-    std::size_t finish_waypoint,
-    std::size_t num_loops,
-    const std::string& id,
-    rmf_traffic::Time earliest_start_time,
-    ConstPriorityPtr priority = nullptr,
-    bool automatic = false);
-
-  /// Generate a loop request
-  ///
-  /// \param[in] start_waypoint
-  ///   The graph index for the starting waypoint of the loop
-  ///
-  /// \param[in] finish_waypoint
-  ///   The graph index for the finishing waypoint of the loop
-  ///
-  /// \param[in] num_loops
-  ///   The number of times the AGV should loop between the start_waypoint and
-  ///   finish_waypoint
-  ///
-  /// \param[in] id
-  ///   A unique id for this request
-  ///
-  /// \param[in] earliest_start_time
-  ///   The desired start time for this request
+  /// \param[in] requester
+  ///   The entity that started this request. This field is optional.
   ///
   /// \param[in] request_time
   ///   The time this request was generated or submitted, to be part of the
-  ///   booking information
-  ///
-  /// \param[in] priority
-  ///   The priority for this request
-  ///
-  /// \param[in] requester
-  ///   The entity that started this request
-  ///
-  /// \param[in] automatic
-  ///   True if this request is auto-generated
+  ///   booking information. This field is optional.
   static ConstRequestPtr make(
     std::size_t start_waypoint,
     std::size_t finish_waypoint,
     std::size_t num_loops,
     const std::string& id,
     rmf_traffic::Time earliest_start_time,
-    rmf_traffic::Time request_time,
     ConstPriorityPtr priority = nullptr,
-    const std::string& requester = "",
-    bool automatic = false);
+    bool automatic = false,
+    std::optional<std::string> requester = std::nullopt,
+    std::optional<rmf_traffic::Time> request_time = std::nullopt);
 };
 
 } // namespace tasks

--- a/rmf_task/include/rmf_task/requests/Loop.hpp
+++ b/rmf_task/include/rmf_task/requests/Loop.hpp
@@ -83,6 +83,38 @@ public:
     rmf_utils::impl_ptr<Implementation> _pimpl;
   };
 
+  /// Generate a loop request
+  ///
+  /// \param[in] start_waypoint
+  ///   The graph index for the starting waypoint of the loop
+  ///
+  /// \param[in] finish_waypoint
+  ///   The graph index for the finishing waypoint of the loop
+  ///
+  /// \param[in] num_loops
+  ///   The number of times the AGV should loop between the start_waypoint and
+  ///   finish_waypoint
+  ///
+  /// \param[in] id
+  ///   A unique id for this request
+  ///
+  /// \param[in] earliest_start_time
+  ///   The desired start time for this request
+  ///
+  /// \param[in] priority
+  ///   The priority for this request
+  ///
+  /// \param[in] automatic
+  ///   True if this request is auto-generated
+  static ConstRequestPtr make(
+    std::size_t start_waypoint,
+    std::size_t finish_waypoint,
+    std::size_t num_loops,
+    const std::string& id,
+    rmf_traffic::Time earliest_start_time,
+    ConstPriorityPtr priority = nullptr,
+    bool automatic = false);
+
   /// Generate a loop request.
   ///
   /// \param[in] start_waypoint
@@ -101,28 +133,27 @@ public:
   /// \param[in] earliest_start_time
   ///   The desired start time for this request.
   ///
+  /// \param[in] requester
+  ///   The entity that started this request. This field is optional.
+  ///
+  /// \param[in] request_time
+  ///   The time this request was generated or submitted.
+  ///
   /// \param[in] priority
   ///   The priority for this request.
   ///
   /// \param[in] automatic
   ///   True if this request is auto-generated, default as false.
-  ///
-  /// \param[in] requester
-  ///   The entity that started this request. This field is optional.
-  ///
-  /// \param[in] request_time
-  ///   The time this request was generated or submitted, to be part of the
-  ///   booking information. This field is optional.
   static ConstRequestPtr make(
     std::size_t start_waypoint,
     std::size_t finish_waypoint,
     std::size_t num_loops,
     const std::string& id,
     rmf_traffic::Time earliest_start_time,
+    const std::string& requester,
+    rmf_traffic::Time request_time,
     ConstPriorityPtr priority = nullptr,
-    bool automatic = false,
-    std::optional<std::string> requester = std::nullopt,
-    std::optional<rmf_traffic::Time> request_time = std::nullopt);
+    bool automatic = false);
 };
 
 } // namespace tasks

--- a/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
@@ -44,23 +44,13 @@ public:
   ///   If nullopt, the AGV will return to its charging_waypoint and remain idle
   ///   there. It will not wait for its battery to charge up before undertaking
   ///   new tasks.
-  ParkRobotFactory(
-    std::optional<std::size_t> parking_waypoint = std::nullopt);
-
-  /// Constructor
   ///
   /// \param[in] requester
-  ///   The identifier for the entity that would make parking requests.
-  ///
-  /// \param[in] parking_waypoint
-  ///   The graph index of the waypoint assigned to this AGV for parking.
-  ///   If nullopt, the AGV will return to its charging_waypoint and remain idle
-  ///   there. It will not wait for its battery to charge up before undertaking
-  ///   new tasks.
+  ///   The identifier for the entity that would make parking requests. This
+  ///   field is optional.
   ParkRobotFactory(
-    const std::string& requester,
-    std::optional<std::size_t> parking_waypoint = std::nullopt);
-
+    std::optional<std::size_t> parking_waypoint = std::nullopt,
+    std::optional<std::string> requester = std::nullopt);
 
   /// Documentation inherited
   ConstRequestPtr make_request(

--- a/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
@@ -18,12 +18,13 @@
 #ifndef RMF_TASK__REQUESTS__FACTORY__PARKROBOTFACTORY_HPP
 #define RMF_TASK__REQUESTS__FACTORY__PARKROBOTFACTORY_HPP
 
+#include <optional>
+#include <functional>
+
 #include <rmf_task/RequestFactory.hpp>
 #include <rmf_task/State.hpp>
 
 #include <rmf_utils/impl_ptr.hpp>
-
-#include <optional>
 
 namespace rmf_task {
 namespace requests {
@@ -50,7 +51,8 @@ public:
   ///   field is optional.
   ParkRobotFactory(
     std::optional<std::size_t> parking_waypoint = std::nullopt,
-    std::optional<std::string> requester = std::nullopt);
+    std::optional<std::string> requester = std::nullopt,
+    std::function<rmf_traffic::Time()> clock = nullptr);
 
   /// Documentation inherited
   ConstRequestPtr make_request(

--- a/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
@@ -18,11 +18,13 @@
 #ifndef RMF_TASK__REQUESTS__FACTORY__PARKROBOTFACTORY_HPP
 #define RMF_TASK__REQUESTS__FACTORY__PARKROBOTFACTORY_HPP
 
+#include <functional>
 #include <optional>
 #include <string>
 
 #include <rmf_task/RequestFactory.hpp>
 #include <rmf_task/State.hpp>
+#include <rmf_traffic/Time.hpp>
 
 #include <rmf_utils/impl_ptr.hpp>
 
@@ -54,6 +56,9 @@ public:
   ///   The identifier of the entity that owns this RequestFactory, that will be
   ///   the designated requester of each new request.
   ///
+  /// \param[in] time_now_cb
+  ///   Callback function that returns the current time.
+  ///
   /// \param[in] parking_waypoint
   ///   The graph index of the waypoint assigned to this AGV for parking.
   ///   If nullopt, the AGV will return to its charging_waypoint and remain idle
@@ -61,6 +66,7 @@ public:
   ///   new tasks.
   ParkRobotFactory(
     const std::string& requester,
+    std::function<rmf_traffic::Time()> time_now_cb,
     std::optional<std::size_t> parking_waypoint = std::nullopt);
 
   /// Documentation inherited

--- a/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
@@ -47,6 +47,21 @@ public:
   ParkRobotFactory(
     std::optional<std::size_t> parking_waypoint = std::nullopt);
 
+  /// Constructor
+  ///
+  /// \param[in] requester
+  ///   The identifier for the entity that would make parking requests.
+  ///
+  /// \param[in] parking_waypoint
+  ///   The graph index of the waypoint assigned to this AGV for parking.
+  ///   If nullopt, the AGV will return to its charging_waypoint and remain idle
+  ///   there. It will not wait for its battery to charge up before undertaking
+  ///   new tasks.
+  ParkRobotFactory(
+    const std::string& requester,
+    std::optional<std::size_t> parking_waypoint = std::nullopt);
+
+
   /// Documentation inherited
   ConstRequestPtr make_request(
     const State& state) const final;

--- a/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
@@ -48,6 +48,10 @@ public:
     std::optional<std::size_t> parking_waypoint = std::nullopt);
 
   /// Documentation inherited
+  [[deprecated]]
+  ConstRequestPtr make_request(const State& state) const final;
+
+  /// Documentation inherited
   ConstRequestPtr make_request(
     const State& state,
     const std::string& requester,

--- a/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
@@ -19,6 +19,7 @@
 #define RMF_TASK__REQUESTS__FACTORY__PARKROBOTFACTORY_HPP
 
 #include <optional>
+#include <string>
 
 #include <rmf_task/RequestFactory.hpp>
 #include <rmf_task/State.hpp>
@@ -47,15 +48,23 @@ public:
   ParkRobotFactory(
     std::optional<std::size_t> parking_waypoint = std::nullopt);
 
-  /// Documentation inherited
-  [[deprecated]]
-  ConstRequestPtr make_request(const State& state) const final;
+  /// Constructor
+  ///
+  /// \param[in] requester
+  ///   The identifier of the entity that owns this RequestFactory, that will be
+  ///   the designated requester of each new request.
+  ///
+  /// \param[in] parking_waypoint
+  ///   The graph index of the waypoint assigned to this AGV for parking.
+  ///   If nullopt, the AGV will return to its charging_waypoint and remain idle
+  ///   there. It will not wait for its battery to charge up before undertaking
+  ///   new tasks.
+  ParkRobotFactory(
+    const std::string& requester,
+    std::optional<std::size_t> parking_waypoint = std::nullopt);
 
   /// Documentation inherited
-  ConstRequestPtr make_request(
-    const State& state,
-    const std::string& requester,
-    rmf_traffic::Time time_now) const final;
+  ConstRequestPtr make_request(const State& state) const final;
 
   class Implementation;
 

--- a/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
@@ -19,7 +19,6 @@
 #define RMF_TASK__REQUESTS__FACTORY__PARKROBOTFACTORY_HPP
 
 #include <optional>
-#include <functional>
 
 #include <rmf_task/RequestFactory.hpp>
 #include <rmf_task/State.hpp>
@@ -45,18 +44,14 @@ public:
   ///   If nullopt, the AGV will return to its charging_waypoint and remain idle
   ///   there. It will not wait for its battery to charge up before undertaking
   ///   new tasks.
-  ///
-  /// \param[in] requester
-  ///   The identifier for the entity that would make parking requests. This
-  ///   field is optional.
   ParkRobotFactory(
-    std::optional<std::size_t> parking_waypoint = std::nullopt,
-    std::optional<std::string> requester = std::nullopt,
-    std::function<rmf_traffic::Time()> clock = nullptr);
+    std::optional<std::size_t> parking_waypoint = std::nullopt);
 
   /// Documentation inherited
   ConstRequestPtr make_request(
-    const State& state) const final;
+    const State& state,
+    const std::string& requester,
+    rmf_traffic::Time time_now) const final;
 
   class Implementation;
 

--- a/rmf_task/src/rmf_task/Request.cpp
+++ b/rmf_task/src/rmf_task/Request.cpp
@@ -45,6 +45,16 @@ Request::Request(
 }
 
 //==============================================================================
+Request::Request(
+  Task::ConstBookingPtr booking,
+  Task::ConstDescriptionPtr description)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation {std::move(booking), std::move(description)}))
+{
+  // Do nothing
+}
+
+//==============================================================================
 const Task::ConstBookingPtr& Request::booking() const
 {
   return _pimpl->booking;

--- a/rmf_task/src/rmf_task/Task.cpp
+++ b/rmf_task/src/rmf_task/Task.cpp
@@ -27,7 +27,9 @@ class Task::Booking::Implementation
 public:
   std::string id;
   rmf_traffic::Time earliest_start_time;
+  rmf_traffic::Time request_time;
   rmf_task::ConstPriorityPtr priority;
+  std::string initiator;
   bool automatic;
 };
 
@@ -41,7 +43,30 @@ Task::Booking::Booking(
       Implementation{
         std::move(id_),
         earliest_start_time_,
+        earliest_start_time_,
         std::move(priority_),
+        std::string("default"),
+        automatic_
+      }))
+{
+  // Do nothing
+}
+
+//==============================================================================
+Task::Booking::Booking(
+  std::string id_,
+  rmf_traffic::Time earliest_start_time_,
+  rmf_traffic::Time request_time,
+  ConstPriorityPtr priority_,
+  std::string initiator_,
+  bool automatic_)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(id_),
+        earliest_start_time_,
+        request_time,
+        std::move(priority_),
+        std::move(initiator_),
         automatic_
       }))
 {
@@ -61,9 +86,21 @@ rmf_traffic::Time Task::Booking::earliest_start_time() const
 }
 
 //==============================================================================
+rmf_traffic::Time Task::Booking::request_time() const
+{
+  return _pimpl->request_time;
+}
+
+//==============================================================================
 ConstPriorityPtr Task::Booking::priority() const
 {
   return _pimpl->priority;
+}
+
+//==============================================================================
+const std::string& Task::Booking::initiator() const
+{
+  return _pimpl->initiator;
 }
 
 //==============================================================================

--- a/rmf_task/src/rmf_task/Task.cpp
+++ b/rmf_task/src/rmf_task/Task.cpp
@@ -28,9 +28,9 @@ public:
   std::string id;
   rmf_traffic::Time earliest_start_time;
   rmf_task::ConstPriorityPtr priority;
-  bool automatic;
   std::optional<std::string> requester;
   std::optional<rmf_traffic::Time> request_time;
+  bool automatic;
 };
 
 //==============================================================================
@@ -38,17 +38,36 @@ Task::Booking::Booking(
   std::string id,
   rmf_traffic::Time earliest_start_time,
   ConstPriorityPtr priority,
-  bool automatic,
-  std::optional<std::string> requester,
-  std::optional<rmf_traffic::Time> request_time)
+  bool automatic)
 : _pimpl(rmf_utils::make_impl<Implementation>(
       Implementation{
         std::move(id),
         earliest_start_time,
         std::move(priority),
+        std::nullopt,
+        std::nullopt,
         automatic,
+      }))
+{
+  // Do nothing
+}
+
+//==============================================================================
+Task::Booking::Booking(
+  std::string id,
+  rmf_traffic::Time earliest_start_time,
+  ConstPriorityPtr priority,
+  std::optional<std::string> requester,
+  std::optional<rmf_traffic::Time> request_time,
+  bool automatic)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(id),
+        earliest_start_time,
+        std::move(priority),
         std::move(requester),
-        std::move(request_time)
+        std::move(request_time),
+        automatic,
       }))
 {
   // Do nothing
@@ -73,12 +92,6 @@ ConstPriorityPtr Task::Booking::priority() const
 }
 
 //==============================================================================
-bool Task::Booking::automatic() const
-{
-  return _pimpl->automatic;
-}
-
-//==============================================================================
 std::optional<std::string> Task::Booking::requester() const
 {
   return _pimpl->requester;
@@ -88,6 +101,12 @@ std::optional<std::string> Task::Booking::requester() const
 std::optional<rmf_traffic::Time> Task::Booking::request_time() const
 {
   return _pimpl->request_time;
+}
+
+//==============================================================================
+bool Task::Booking::automatic() const
+{
+  return _pimpl->automatic;
 }
 
 //==============================================================================

--- a/rmf_task/src/rmf_task/Task.cpp
+++ b/rmf_task/src/rmf_task/Task.cpp
@@ -29,7 +29,7 @@ public:
   rmf_traffic::Time earliest_start_time;
   rmf_traffic::Time request_time;
   rmf_task::ConstPriorityPtr priority;
-  std::string initiator;
+  std::string requester;
   bool automatic;
 };
 
@@ -58,7 +58,7 @@ Task::Booking::Booking(
   rmf_traffic::Time earliest_start_time_,
   rmf_traffic::Time request_time,
   ConstPriorityPtr priority_,
-  std::string initiator_,
+  std::string requester_,
   bool automatic_)
 : _pimpl(rmf_utils::make_impl<Implementation>(
       Implementation{
@@ -66,7 +66,7 @@ Task::Booking::Booking(
         earliest_start_time_,
         request_time,
         std::move(priority_),
-        std::move(initiator_),
+        std::move(requester_),
         automatic_
       }))
 {
@@ -98,9 +98,9 @@ ConstPriorityPtr Task::Booking::priority() const
 }
 
 //==============================================================================
-const std::string& Task::Booking::initiator() const
+const std::string& Task::Booking::requester() const
 {
-  return _pimpl->initiator;
+  return _pimpl->requester;
 }
 
 //==============================================================================

--- a/rmf_task/src/rmf_task/Task.cpp
+++ b/rmf_task/src/rmf_task/Task.cpp
@@ -27,47 +27,28 @@ class Task::Booking::Implementation
 public:
   std::string id;
   rmf_traffic::Time earliest_start_time;
-  rmf_traffic::Time request_time;
   rmf_task::ConstPriorityPtr priority;
-  std::string requester;
   bool automatic;
+  std::optional<std::string> requester;
+  std::optional<rmf_traffic::Time> request_time;
 };
 
 //==============================================================================
 Task::Booking::Booking(
-  std::string id_,
-  rmf_traffic::Time earliest_start_time_,
-  ConstPriorityPtr priority_,
-  bool automatic_)
+  std::string id,
+  rmf_traffic::Time earliest_start_time,
+  ConstPriorityPtr priority,
+  bool automatic,
+  std::optional<std::string> requester,
+  std::optional<rmf_traffic::Time> request_time)
 : _pimpl(rmf_utils::make_impl<Implementation>(
       Implementation{
-        std::move(id_),
-        earliest_start_time_,
-        earliest_start_time_,
-        std::move(priority_),
-        std::string(""),
-        automatic_
-      }))
-{
-  // Do nothing
-}
-
-//==============================================================================
-Task::Booking::Booking(
-  std::string id_,
-  rmf_traffic::Time earliest_start_time_,
-  rmf_traffic::Time request_time,
-  ConstPriorityPtr priority_,
-  std::string requester_,
-  bool automatic_)
-: _pimpl(rmf_utils::make_impl<Implementation>(
-      Implementation{
-        std::move(id_),
-        earliest_start_time_,
-        request_time,
-        std::move(priority_),
-        std::move(requester_),
-        automatic_
+        std::move(id),
+        earliest_start_time,
+        std::move(priority),
+        automatic,
+        std::move(requester),
+        std::move(request_time)
       }))
 {
   // Do nothing
@@ -86,27 +67,27 @@ rmf_traffic::Time Task::Booking::earliest_start_time() const
 }
 
 //==============================================================================
-rmf_traffic::Time Task::Booking::request_time() const
-{
-  return _pimpl->request_time;
-}
-
-//==============================================================================
 ConstPriorityPtr Task::Booking::priority() const
 {
   return _pimpl->priority;
 }
 
 //==============================================================================
-const std::string& Task::Booking::requester() const
+bool Task::Booking::automatic() const
+{
+  return _pimpl->automatic;
+}
+
+//==============================================================================
+std::optional<std::string> Task::Booking::requester() const
 {
   return _pimpl->requester;
 }
 
 //==============================================================================
-bool Task::Booking::automatic() const
+std::optional<rmf_traffic::Time> Task::Booking::request_time() const
 {
-  return _pimpl->automatic;
+  return _pimpl->request_time;
 }
 
 //==============================================================================

--- a/rmf_task/src/rmf_task/Task.cpp
+++ b/rmf_task/src/rmf_task/Task.cpp
@@ -45,7 +45,7 @@ Task::Booking::Booking(
         earliest_start_time_,
         earliest_start_time_,
         std::move(priority_),
-        std::string("default"),
+        std::string(""),
         automatic_
       }))
 {

--- a/rmf_task/src/rmf_task/Task.cpp
+++ b/rmf_task/src/rmf_task/Task.cpp
@@ -57,15 +57,15 @@ Task::Booking::Booking(
   std::string id,
   rmf_traffic::Time earliest_start_time,
   ConstPriorityPtr priority,
-  std::optional<std::string> requester,
-  std::optional<rmf_traffic::Time> request_time,
+  const std::string& requester,
+  rmf_traffic::Time request_time,
   bool automatic)
 : _pimpl(rmf_utils::make_impl<Implementation>(
       Implementation{
         std::move(id),
         earliest_start_time,
         std::move(priority),
-        std::move(requester),
+        requester,
         std::move(request_time),
         automatic,
       }))

--- a/rmf_task/src/rmf_task/TaskPlanner.cpp
+++ b/rmf_task/src/rmf_task/TaskPlanner.cpp
@@ -378,7 +378,7 @@ public:
 
   ConstRequestPtr make_charging_request(rmf_traffic::Time start_time)
   {
-    return rmf_task::requests::ChargeBattery::make(start_time);
+    return rmf_task::requests::ChargeBattery::make(start_time, start_time);
   }
 
   TaskPlanner::Assignments prune_assignments(

--- a/rmf_task/src/rmf_task/TaskPlanner.cpp
+++ b/rmf_task/src/rmf_task/TaskPlanner.cpp
@@ -370,13 +370,14 @@ const rmf_traffic::Duration segmentation_threshold =
 class TaskPlanner::Implementation
 {
 public:
-  static constexpr std::string_view DefaultTaskPlannerName = "task_planner";
-
   Configuration config;
   Options default_options;
   ConstTravelEstimatorPtr travel_estimator;
+  std::string task_planner_name;
   bool check_priority = false;
   ConstCostCalculatorPtr cost_calculator = nullptr;
+
+  static constexpr std::string_view DefaultTaskPlannerName = "task_planner";
 
   ConstRequestPtr make_charging_request(
     rmf_traffic::Time start_time,
@@ -386,7 +387,7 @@ public:
       start_time,
       nullptr,
       true,
-      std::string(DefaultTaskPlannerName),
+      task_planner_name,
       time_now);
   }
 
@@ -442,7 +443,7 @@ public:
       const auto& state = agent.back().finish_state();
       const auto request = factory.make_request(
         state,
-        std::string(DefaultTaskPlannerName),
+        task_planner_name,
         time_now);
 
       // TODO(YV) Currently we are unable to recursively call complete_solve()
@@ -1112,7 +1113,24 @@ TaskPlanner::TaskPlanner(
       Implementation{
         configuration,
         default_options,
-        std::make_shared<TravelEstimator>(configuration.parameters())
+        std::make_shared<TravelEstimator>(configuration.parameters()),
+        std::string(Implementation::DefaultTaskPlannerName)
+      }))
+{
+  // Do nothing
+}
+
+// ============================================================================
+TaskPlanner::TaskPlanner(
+  Configuration configuration,
+  Options default_options,
+  const std::string& task_planner_name)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        configuration,
+        default_options,
+        std::make_shared<TravelEstimator>(configuration.parameters()),
+        task_planner_name
       }))
 {
   // Do nothing

--- a/rmf_task/src/rmf_task/TaskPlanner.cpp
+++ b/rmf_task/src/rmf_task/TaskPlanner.cpp
@@ -385,10 +385,10 @@ public:
   {
     return rmf_task::requests::ChargeBattery::make(
       start_time,
-      nullptr,
-      true,
       task_planner_name,
-      time_now);
+      time_now,
+      nullptr,
+      true);
   }
 
   TaskPlanner::Assignments prune_assignments(
@@ -441,10 +441,7 @@ public:
       }
 
       const auto& state = agent.back().finish_state();
-      const auto request = factory.make_request(
-        state,
-        task_planner_name,
-        time_now);
+      const auto request = factory.make_request(state);
 
       // TODO(YV) Currently we are unable to recursively call complete_solve()
       // here as the prune_assignments() function will remove any ChargeBattery
@@ -646,6 +643,7 @@ public:
         config.parameters(),
         request,
         *travel_estimator,
+        task_planner_name,
         error);
 
       if (!pending_task)

--- a/rmf_task/src/rmf_task/TaskPlanner.cpp
+++ b/rmf_task/src/rmf_task/TaskPlanner.cpp
@@ -378,7 +378,12 @@ public:
 
   ConstRequestPtr make_charging_request(rmf_traffic::Time start_time)
   {
-    return rmf_task::requests::ChargeBattery::make(start_time, start_time);
+    return rmf_task::requests::ChargeBattery::make(
+      start_time,
+      nullptr,
+      true,
+      std::nullopt,
+      start_time);
   }
 
   TaskPlanner::Assignments prune_assignments(

--- a/rmf_task/src/rmf_task/TaskPlanner.cpp
+++ b/rmf_task/src/rmf_task/TaskPlanner.cpp
@@ -373,7 +373,7 @@ public:
   Configuration config;
   Options default_options;
   ConstTravelEstimatorPtr travel_estimator;
-  std::string task_planner_name;
+  std::string planner_id;
   bool check_priority = false;
   ConstCostCalculatorPtr cost_calculator = nullptr;
 
@@ -385,7 +385,7 @@ public:
   {
     return rmf_task::requests::ChargeBattery::make(
       start_time,
-      task_planner_name,
+      planner_id,
       time_now,
       nullptr,
       true);
@@ -643,7 +643,7 @@ public:
         config.parameters(),
         request,
         *travel_estimator,
-        task_planner_name,
+        planner_id,
         error);
 
       if (!pending_task)
@@ -1120,15 +1120,15 @@ TaskPlanner::TaskPlanner(
 
 // ============================================================================
 TaskPlanner::TaskPlanner(
+  const std::string& planner_id,
   Configuration configuration,
-  Options default_options,
-  const std::string& task_planner_name)
+  Options default_options)
 : _pimpl(rmf_utils::make_impl<Implementation>(
       Implementation{
         configuration,
         default_options,
         std::make_shared<TravelEstimator>(configuration.parameters()),
-        task_planner_name
+        planner_id
       }))
 {
   // Do nothing

--- a/rmf_task/src/rmf_task/internal_task_planning.cpp
+++ b/rmf_task/src/rmf_task/internal_task_planning.cpp
@@ -124,7 +124,11 @@ std::shared_ptr<Candidates> Candidates::make(
     else
     {
       auto charge_battery = requests::ChargeBattery::make(
-        start_time, start_time);
+        start_time,
+        nullptr,
+        true,
+        std::nullopt,
+        start_time);
       const auto battery_model = charge_battery->description()->make_model(
         start_time,
         parameters);

--- a/rmf_task/src/rmf_task/internal_task_planning.cpp
+++ b/rmf_task/src/rmf_task/internal_task_planning.cpp
@@ -102,7 +102,7 @@ std::shared_ptr<Candidates> Candidates::make(
   const Parameters& parameters,
   const Task::Model& task_model,
   const TravelEstimator& travel_estimator,
-  const std::string& requester,
+  const std::string& planner_id,
   TaskPlanner::TaskPlannerError& error)
 {
   Map initial_map;
@@ -126,7 +126,7 @@ std::shared_ptr<Candidates> Candidates::make(
     {
       auto charge_battery = requests::ChargeBattery::make(
         start_time,
-        requester,
+        planner_id,
         start_time,
         nullptr,
         true);
@@ -201,7 +201,7 @@ std::shared_ptr<PendingTask> PendingTask::make(
   const Parameters& parameters,
   const ConstRequestPtr request_,
   const TravelEstimator& travel_estimator,
-  const std::string& requester,
+  const std::string& planner_id,
   TaskPlanner::TaskPlannerError& error)
 {
   const auto earliest_start_time = std::max(
@@ -211,7 +211,7 @@ std::shared_ptr<PendingTask> PendingTask::make(
     earliest_start_time, parameters);
 
   const auto candidates = Candidates::make(start_time, initial_states,
-      constraints, parameters, *model, travel_estimator, requester, error);
+      constraints, parameters, *model, travel_estimator, planner_id, error);
 
   if (!candidates)
     return nullptr;

--- a/rmf_task/src/rmf_task/internal_task_planning.cpp
+++ b/rmf_task/src/rmf_task/internal_task_planning.cpp
@@ -124,7 +124,7 @@ std::shared_ptr<Candidates> Candidates::make(
     else
     {
       auto charge_battery = requests::ChargeBattery::make(
-        start_time);
+        start_time, start_time);
       const auto battery_model = charge_battery->description()->make_model(
         start_time,
         parameters);

--- a/rmf_task/src/rmf_task/internal_task_planning.cpp
+++ b/rmf_task/src/rmf_task/internal_task_planning.cpp
@@ -102,6 +102,7 @@ std::shared_ptr<Candidates> Candidates::make(
   const Parameters& parameters,
   const Task::Model& task_model,
   const TravelEstimator& travel_estimator,
+  const std::string& requester,
   TaskPlanner::TaskPlannerError& error)
 {
   Map initial_map;
@@ -125,10 +126,10 @@ std::shared_ptr<Candidates> Candidates::make(
     {
       auto charge_battery = requests::ChargeBattery::make(
         start_time,
+        requester,
+        start_time,
         nullptr,
-        true,
-        std::nullopt,
-        start_time);
+        true);
       const auto battery_model = charge_battery->description()->make_model(
         start_time,
         parameters);
@@ -200,6 +201,7 @@ std::shared_ptr<PendingTask> PendingTask::make(
   const Parameters& parameters,
   const ConstRequestPtr request_,
   const TravelEstimator& travel_estimator,
+  const std::string& requester,
   TaskPlanner::TaskPlannerError& error)
 {
   const auto earliest_start_time = std::max(
@@ -209,7 +211,7 @@ std::shared_ptr<PendingTask> PendingTask::make(
     earliest_start_time, parameters);
 
   const auto candidates = Candidates::make(start_time, initial_states,
-      constraints, parameters, *model, travel_estimator, error);
+      constraints, parameters, *model, travel_estimator, requester, error);
 
   if (!candidates)
     return nullptr;

--- a/rmf_task/src/rmf_task/internal_task_planning.hpp
+++ b/rmf_task/src/rmf_task/internal_task_planning.hpp
@@ -77,7 +77,7 @@ public:
     const Parameters& parameters,
     const Task::Model& task_model,
     const TravelEstimator& travel_estimator,
-    const std::string& requester,
+    const std::string& planner_id,
     TaskPlanner::TaskPlannerError& error);
 
   Candidates(const Candidates& other);
@@ -118,7 +118,7 @@ public:
     const Parameters& parameters,
     const ConstRequestPtr request_,
     const TravelEstimator& travel_estimator,
-    const std::string& requester,
+    const std::string& planner_id,
     TaskPlanner::TaskPlannerError& error);
 
   rmf_task::ConstRequestPtr request;

--- a/rmf_task/src/rmf_task/internal_task_planning.hpp
+++ b/rmf_task/src/rmf_task/internal_task_planning.hpp
@@ -77,6 +77,7 @@ public:
     const Parameters& parameters,
     const Task::Model& task_model,
     const TravelEstimator& travel_estimator,
+    const std::string& requester,
     TaskPlanner::TaskPlannerError& error);
 
   Candidates(const Candidates& other);
@@ -117,6 +118,7 @@ public:
     const Parameters& parameters,
     const ConstRequestPtr request_,
     const TravelEstimator& travel_estimator,
+    const std::string& requester,
     TaskPlanner::TaskPlannerError& error);
 
   rmf_task::ConstRequestPtr request;

--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -220,7 +220,7 @@ ConstRequestPtr ChargeBattery::make(
   rmf_traffic::Time earliest_start_time,
   rmf_traffic::Time request_time,
   ConstPriorityPtr priority,
-  const std::string& initiator,
+  const std::string& requester,
   bool automatic)
 {
   std::string id = "Charge" + generate_uuid();
@@ -230,7 +230,7 @@ ConstRequestPtr ChargeBattery::make(
     earliest_start_time,
     request_time,
     std::move(priority),
-    initiator,
+    requester,
     automatic);
   const auto description = Description::make();
   return std::make_shared<Request>(std::move(booking), description);

--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -215,9 +215,9 @@ ConstRequestPtr ChargeBattery::make(
     id,
     earliest_start_time,
     std::move(priority),
-    automatic,
     std::move(requester),
-    std::move(request_time));
+    std::move(request_time),
+    automatic);
   const auto description = Description::make();
   return std::make_shared<Request>(
     std::move(booking),

--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -205,9 +205,7 @@ auto ChargeBattery::Description::generate_info(
 ConstRequestPtr ChargeBattery::make(
   rmf_traffic::Time earliest_start_time,
   ConstPriorityPtr priority,
-  bool automatic,
-  std::optional<std::string> requester,
-  std::optional<rmf_traffic::Time> request_time)
+  bool automatic)
 {
   std::string id = "Charge" + generate_uuid();
   Task::ConstBookingPtr booking =
@@ -215,8 +213,29 @@ ConstRequestPtr ChargeBattery::make(
     id,
     earliest_start_time,
     std::move(priority),
-    std::move(requester),
-    std::move(request_time),
+    automatic);
+  const auto description = Description::make();
+  return std::make_shared<Request>(
+    std::move(booking),
+    std::move(description));
+}
+
+//==============================================================================
+ConstRequestPtr ChargeBattery::make(
+  rmf_traffic::Time earliest_start_time,
+  const std::string& requester,
+  rmf_traffic::Time request_time,
+  ConstPriorityPtr priority,
+  bool automatic)
+{
+  std::string id = "Charge" + generate_uuid();
+  Task::ConstBookingPtr booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+    id,
+    earliest_start_time,
+    std::move(priority),
+    requester,
+    request_time,
     automatic);
   const auto description = Description::make();
   return std::make_shared<Request>(

--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -205,33 +205,19 @@ auto ChargeBattery::Description::generate_info(
 ConstRequestPtr ChargeBattery::make(
   rmf_traffic::Time earliest_start_time,
   ConstPriorityPtr priority,
-  bool automatic)
-{
-  return ChargeBattery::make(
-    earliest_start_time,
-    earliest_start_time,
-    priority,
-    "",
-    automatic);
-}
-
-//==============================================================================
-ConstRequestPtr ChargeBattery::make(
-  rmf_traffic::Time earliest_start_time,
-  rmf_traffic::Time request_time,
-  ConstPriorityPtr priority,
-  const std::string& requester,
-  bool automatic)
+  bool automatic,
+  std::optional<std::string> requester,
+  std::optional<rmf_traffic::Time> request_time)
 {
   std::string id = "Charge" + generate_uuid();
   Task::ConstBookingPtr booking =
     std::make_shared<const rmf_task::Task::Booking>(
     id,
     earliest_start_time,
-    request_time,
     std::move(priority),
-    requester,
-    automatic);
+    automatic,
+    std::move(requester),
+    std::move(request_time));
   const auto description = Description::make();
   return std::make_shared<Request>(std::move(booking), description);
 }

--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -207,13 +207,33 @@ ConstRequestPtr ChargeBattery::make(
   ConstPriorityPtr priority,
   bool automatic)
 {
+  return ChargeBattery::make(
+    earliest_start_time,
+    earliest_start_time,
+    priority,
+    "",
+    automatic);
+}
 
+//==============================================================================
+ConstRequestPtr ChargeBattery::make(
+  rmf_traffic::Time earliest_start_time,
+  rmf_traffic::Time request_time,
+  ConstPriorityPtr priority,
+  const std::string& initiator,
+  bool automatic)
+{
   std::string id = "Charge" + generate_uuid();
+  Task::ConstBookingPtr booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+    id,
+    earliest_start_time,
+    request_time,
+    std::move(priority),
+    initiator,
+    automatic);
   const auto description = Description::make();
-
-  return std::make_shared<Request>(
-    id, earliest_start_time, priority, description, automatic);
-
+  return std::make_shared<Request>(std::move(booking), description);
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -219,7 +219,9 @@ ConstRequestPtr ChargeBattery::make(
     std::move(requester),
     std::move(request_time));
   const auto description = Description::make();
-  return std::make_shared<Request>(std::move(booking), description);
+  return std::make_shared<Request>(
+    std::move(booking),
+    std::move(description));
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -207,10 +207,10 @@ ConstRequestPtr ChargeBattery::make(
   ConstPriorityPtr priority,
   bool automatic)
 {
-  std::string id = "Charge" + generate_uuid();
+  const std::string id = "Charge" + generate_uuid();
   Task::ConstBookingPtr booking =
     std::make_shared<const rmf_task::Task::Booking>(
-    id,
+    std::move(id),
     earliest_start_time,
     std::move(priority),
     automatic);
@@ -228,10 +228,10 @@ ConstRequestPtr ChargeBattery::make(
   ConstPriorityPtr priority,
   bool automatic)
 {
-  std::string id = "Charge" + generate_uuid();
+  const std::string id = "Charge" + generate_uuid();
   Task::ConstBookingPtr booking =
     std::make_shared<const rmf_task::Task::Booking>(
-    id,
+    std::move(id),
     earliest_start_time,
     std::move(priority),
     requester,

--- a/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
@@ -25,19 +25,14 @@ namespace requests {
 class ChargeBatteryFactory::Implementation
 {
 public:
-  std::string requester;
+  std::optional<std::string> requester;
+
 };
 
 //==============================================================================
-ChargeBatteryFactory::ChargeBatteryFactory()
-: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{""}))
-{
-  // Do nothing
-}
-
-//==============================================================================
-ChargeBatteryFactory::ChargeBatteryFactory(const std::string& requester)
-: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{requester}))
+ChargeBatteryFactory::ChargeBatteryFactory(std::optional<std::string> requester)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{std::move(requester)}))
 {
   // Do nothing
 }
@@ -48,9 +43,10 @@ ConstRequestPtr ChargeBatteryFactory::make_request(
 {
   return ChargeBattery::make(
     state.time().value(),
-    state.time().value(),
     nullptr,
-    _pimpl->requester);
+    true,
+    _pimpl->requester,
+    state.time().value());
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
@@ -24,11 +24,20 @@ namespace requests {
 //==============================================================================
 class ChargeBatteryFactory::Implementation
 {
+public:
+  std::optional<std::string> requester;
 };
 
 //==============================================================================
 ChargeBatteryFactory::ChargeBatteryFactory()
-: _pimpl(rmf_utils::make_impl<Implementation>(Implementation()))
+: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{std::nullopt}))
+{
+  // Do nothing
+}
+
+//==============================================================================
+ChargeBatteryFactory::ChargeBatteryFactory(const std::string& requester)
+: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{requester}))
 {
   // Do nothing
 }
@@ -36,26 +45,19 @@ ChargeBatteryFactory::ChargeBatteryFactory()
 //==============================================================================
 ConstRequestPtr ChargeBatteryFactory::make_request(const State& state) const
 {
+  if (_pimpl->requester.has_value())
+  {
+    return ChargeBattery::make(
+      state.time().value(),
+      _pimpl->requester.value(),
+      state.time().value(),
+      nullptr,
+      true);
+  }
   return ChargeBattery::make(
     state.time().value(),
     nullptr,
-    true,
-    std::nullopt,
-    std::nullopt);
-}
-
-//==============================================================================
-ConstRequestPtr ChargeBatteryFactory::make_request(
-  const State& state,
-  const std::string& requester,
-  rmf_traffic::Time time_now) const
-{
-  return ChargeBattery::make(
-    state.time().value(),
-    nullptr,
-    true,
-    requester,
-    time_now);
+    true);
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
@@ -34,6 +34,17 @@ ChargeBatteryFactory::ChargeBatteryFactory()
 }
 
 //==============================================================================
+ConstRequestPtr ChargeBatteryFactory::make_request(const State& state) const
+{
+  return ChargeBattery::make(
+    state.time().value(),
+    nullptr,
+    true,
+    std::nullopt,
+    std::nullopt);
+}
+
+//==============================================================================
 ConstRequestPtr ChargeBatteryFactory::make_request(
   const State& state,
   const std::string& requester,

--- a/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
@@ -24,29 +24,27 @@ namespace requests {
 //==============================================================================
 class ChargeBatteryFactory::Implementation
 {
-public:
-  std::optional<std::string> requester;
-
 };
 
 //==============================================================================
-ChargeBatteryFactory::ChargeBatteryFactory(std::optional<std::string> requester)
-: _pimpl(rmf_utils::make_impl<Implementation>(
-      Implementation{std::move(requester)}))
+ChargeBatteryFactory::ChargeBatteryFactory()
+: _pimpl(rmf_utils::make_impl<Implementation>(Implementation()))
 {
   // Do nothing
 }
 
 //==============================================================================
 ConstRequestPtr ChargeBatteryFactory::make_request(
-  const State& state) const
+  const State& state,
+  const std::string& requester,
+  rmf_traffic::Time time_now) const
 {
   return ChargeBattery::make(
     state.time().value(),
     nullptr,
     true,
-    _pimpl->requester,
-    state.time().value());
+    requester,
+    time_now);
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
@@ -24,12 +24,20 @@ namespace requests {
 //==============================================================================
 class ChargeBatteryFactory::Implementation
 {
-
+public:
+  std::string requester;
 };
 
 //==============================================================================
 ChargeBatteryFactory::ChargeBatteryFactory()
-: _pimpl(rmf_utils::make_impl<Implementation>(Implementation()))
+: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{""}))
+{
+  // Do nothing
+}
+
+//==============================================================================
+ChargeBatteryFactory::ChargeBatteryFactory(const std::string& requester)
+: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{requester}))
 {
   // Do nothing
 }
@@ -38,7 +46,11 @@ ChargeBatteryFactory::ChargeBatteryFactory()
 ConstRequestPtr ChargeBatteryFactory::make_request(
   const State& state) const
 {
-  return ChargeBattery::make(state.time().value());
+  return ChargeBattery::make(
+    state.time().value(),
+    state.time().value(),
+    nullptr,
+    _pimpl->requester);
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
@@ -26,18 +26,23 @@ class ChargeBatteryFactory::Implementation
 {
 public:
   std::optional<std::string> requester;
+  std::function<rmf_traffic::Time()> time_now_cb;
 };
 
 //==============================================================================
 ChargeBatteryFactory::ChargeBatteryFactory()
-: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{std::nullopt}))
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{std::nullopt, nullptr}))
 {
   // Do nothing
 }
 
 //==============================================================================
-ChargeBatteryFactory::ChargeBatteryFactory(const std::string& requester)
-: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{requester}))
+ChargeBatteryFactory::ChargeBatteryFactory(
+  const std::string& requester,
+  std::function<rmf_traffic::Time()> time_now_cb)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{requester, std::move(time_now_cb)}))
 {
   // Do nothing
 }
@@ -45,12 +50,13 @@ ChargeBatteryFactory::ChargeBatteryFactory(const std::string& requester)
 //==============================================================================
 ConstRequestPtr ChargeBatteryFactory::make_request(const State& state) const
 {
-  if (_pimpl->requester.has_value())
+
+  if (_pimpl->requester.has_value() && _pimpl->time_now_cb)
   {
     return ChargeBattery::make(
       state.time().value(),
       _pimpl->requester.value(),
-      state.time().value(),
+      _pimpl->time_now_cb(),
       nullptr,
       true);
   }

--- a/rmf_task/src/rmf_task/requests/Clean.cpp
+++ b/rmf_task/src/rmf_task/requests/Clean.cpp
@@ -295,7 +295,9 @@ ConstRequestPtr Clean::make(
     start_waypoint,
     end_waypoint,
     cleaning_path);
-  return std::make_shared<Request>(std::move(booking), description);
+  return std::make_shared<Request>(
+    std::move(booking),
+    std::move(description));
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/Clean.cpp
+++ b/rmf_task/src/rmf_task/requests/Clean.cpp
@@ -281,13 +281,43 @@ ConstRequestPtr Clean::make(
   ConstPriorityPtr priority,
   bool automatic)
 {
+  return make(
+    start_waypoint,
+    end_waypoint,
+    cleaning_path,
+    id,
+    earliest_start_time,
+    earliest_start_time,
+    priority,
+    "",
+    automatic);
+}
+
+//==============================================================================
+ConstRequestPtr Clean::make(
+  std::size_t start_waypoint,
+  std::size_t end_waypoint,
+  const rmf_traffic::Trajectory& cleaning_path,
+  const std::string& id,
+  rmf_traffic::Time earliest_start_time,
+  rmf_traffic::Time request_time,
+  ConstPriorityPtr priority,
+  const std::string& requester,
+  bool automatic)
+{
+  Task::ConstBookingPtr booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+    id,
+    earliest_start_time,
+    request_time,
+    std::move(priority),
+    requester,
+    automatic);
   const auto description = Clean::Description::make(
     start_waypoint,
     end_waypoint,
     cleaning_path);
-
-  return std::make_shared<Request>(
-    id, earliest_start_time, priority, description, automatic);
+  return std::make_shared<Request>(std::move(booking), description);
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/Clean.cpp
+++ b/rmf_task/src/rmf_task/requests/Clean.cpp
@@ -288,9 +288,9 @@ ConstRequestPtr Clean::make(
     id,
     earliest_start_time,
     std::move(priority),
-    automatic,
     std::move(requester),
-    std::move(request_time));
+    std::move(request_time),
+    automatic);
   const auto description = Clean::Description::make(
     start_waypoint,
     end_waypoint,

--- a/rmf_task/src/rmf_task/requests/Clean.cpp
+++ b/rmf_task/src/rmf_task/requests/Clean.cpp
@@ -279,40 +279,18 @@ ConstRequestPtr Clean::make(
   const std::string& id,
   rmf_traffic::Time earliest_start_time,
   ConstPriorityPtr priority,
-  bool automatic)
-{
-  return make(
-    start_waypoint,
-    end_waypoint,
-    cleaning_path,
-    id,
-    earliest_start_time,
-    earliest_start_time,
-    priority,
-    "",
-    automatic);
-}
-
-//==============================================================================
-ConstRequestPtr Clean::make(
-  std::size_t start_waypoint,
-  std::size_t end_waypoint,
-  const rmf_traffic::Trajectory& cleaning_path,
-  const std::string& id,
-  rmf_traffic::Time earliest_start_time,
-  rmf_traffic::Time request_time,
-  ConstPriorityPtr priority,
-  const std::string& requester,
-  bool automatic)
+  bool automatic,
+  std::optional<std::string> requester,
+  std::optional<rmf_traffic::Time> request_time)
 {
   Task::ConstBookingPtr booking =
     std::make_shared<const rmf_task::Task::Booking>(
     id,
     earliest_start_time,
-    request_time,
     std::move(priority),
-    requester,
-    automatic);
+    automatic,
+    std::move(requester),
+    std::move(request_time));
   const auto description = Clean::Description::make(
     start_waypoint,
     end_waypoint,

--- a/rmf_task/src/rmf_task/requests/Clean.cpp
+++ b/rmf_task/src/rmf_task/requests/Clean.cpp
@@ -279,17 +279,42 @@ ConstRequestPtr Clean::make(
   const std::string& id,
   rmf_traffic::Time earliest_start_time,
   ConstPriorityPtr priority,
-  bool automatic,
-  std::optional<std::string> requester,
-  std::optional<rmf_traffic::Time> request_time)
+  bool automatic)
 {
   Task::ConstBookingPtr booking =
     std::make_shared<const rmf_task::Task::Booking>(
     id,
     earliest_start_time,
     std::move(priority),
-    std::move(requester),
-    std::move(request_time),
+    automatic);
+  const auto description = Clean::Description::make(
+    start_waypoint,
+    end_waypoint,
+    cleaning_path);
+  return std::make_shared<Request>(
+    std::move(booking),
+    std::move(description));
+}
+
+//==============================================================================
+ConstRequestPtr Clean::make(
+  std::size_t start_waypoint,
+  std::size_t end_waypoint,
+  const rmf_traffic::Trajectory& cleaning_path,
+  const std::string& id,
+  rmf_traffic::Time earliest_start_time,
+  const std::string& requester,
+  rmf_traffic::Time request_time,
+  ConstPriorityPtr priority,
+  bool automatic)
+{
+  Task::ConstBookingPtr booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+    id,
+    earliest_start_time,
+    std::move(priority),
+    requester,
+    request_time,
     automatic);
   const auto description = Clean::Description::make(
     start_waypoint,

--- a/rmf_task/src/rmf_task/requests/Delivery.cpp
+++ b/rmf_task/src/rmf_task/requests/Delivery.cpp
@@ -349,7 +349,9 @@ ConstRequestPtr Delivery::make(
     std::move(payload),
     std::move(pickup_from_dispenser),
     std::move(dropoff_to_ingestor));
-  return std::make_shared<Request>(std::move(booking), description);
+  return std::make_shared<Request>(
+    std::move(booking),
+    std::move(description));
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/Delivery.cpp
+++ b/rmf_task/src/rmf_task/requests/Delivery.cpp
@@ -329,48 +329,18 @@ ConstRequestPtr Delivery::make(
   ConstPriorityPtr priority,
   bool automatic,
   std::string pickup_from_dispenser,
-  std::string dropoff_to_ingestor)
-{
-  return make(
-    pickup_waypoint,
-    pickup_wait,
-    dropoff_waypoint,
-    dropoff_wait,
-    payload,
-    id,
-    earliest_start_time,
-    earliest_start_time,
-    priority,
-    "",
-    automatic,
-    pickup_from_dispenser,
-    dropoff_to_ingestor);
-}
-
-//==============================================================================
-ConstRequestPtr Delivery::make(
-  std::size_t pickup_waypoint,
-  rmf_traffic::Duration pickup_wait,
-  std::size_t dropoff_waypoint,
-  rmf_traffic::Duration dropoff_wait,
-  Payload payload,
-  const std::string& id,
-  rmf_traffic::Time earliest_start_time,
-  rmf_traffic::Time request_time,
-  ConstPriorityPtr priority,
-  const std::string& requester,
-  bool automatic,
-  std::string pickup_from_dispenser,
-  std::string dropoff_to_ingestor)
+  std::string dropoff_to_ingestor,
+  std::optional<std::string> requester,
+  std::optional<rmf_traffic::Time> request_time)
 {
   Task::ConstBookingPtr booking =
     std::make_shared<const rmf_task::Task::Booking>(
     id,
     earliest_start_time,
-    request_time,
     std::move(priority),
-    requester,
-    automatic);
+    automatic,
+    std::move(requester),
+    std::move(request_time));
   const auto description = Description::make(
     pickup_waypoint,
     pickup_wait,

--- a/rmf_task/src/rmf_task/requests/Delivery.cpp
+++ b/rmf_task/src/rmf_task/requests/Delivery.cpp
@@ -331,6 +331,46 @@ ConstRequestPtr Delivery::make(
   std::string pickup_from_dispenser,
   std::string dropoff_to_ingestor)
 {
+  return make(
+    pickup_waypoint,
+    pickup_wait,
+    dropoff_waypoint,
+    dropoff_wait,
+    payload,
+    id,
+    earliest_start_time,
+    earliest_start_time,
+    priority,
+    "",
+    automatic,
+    pickup_from_dispenser,
+    dropoff_to_ingestor);
+}
+
+//==============================================================================
+ConstRequestPtr Delivery::make(
+  std::size_t pickup_waypoint,
+  rmf_traffic::Duration pickup_wait,
+  std::size_t dropoff_waypoint,
+  rmf_traffic::Duration dropoff_wait,
+  Payload payload,
+  const std::string& id,
+  rmf_traffic::Time earliest_start_time,
+  rmf_traffic::Time request_time,
+  ConstPriorityPtr priority,
+  const std::string& requester,
+  bool automatic,
+  std::string pickup_from_dispenser,
+  std::string dropoff_to_ingestor)
+{
+  Task::ConstBookingPtr booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+    id,
+    earliest_start_time,
+    request_time,
+    std::move(priority),
+    requester,
+    automatic);
   const auto description = Description::make(
     pickup_waypoint,
     pickup_wait,
@@ -339,9 +379,7 @@ ConstRequestPtr Delivery::make(
     std::move(payload),
     std::move(pickup_from_dispenser),
     std::move(dropoff_to_ingestor));
-
-  return std::make_shared<Request>(
-    id, earliest_start_time, std::move(priority), description, automatic);
+  return std::make_shared<Request>(std::move(booking), description);
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/Delivery.cpp
+++ b/rmf_task/src/rmf_task/requests/Delivery.cpp
@@ -329,17 +329,50 @@ ConstRequestPtr Delivery::make(
   ConstPriorityPtr priority,
   bool automatic,
   std::string pickup_from_dispenser,
-  std::string dropoff_to_ingestor,
-  std::optional<std::string> requester,
-  std::optional<rmf_traffic::Time> request_time)
+  std::string dropoff_to_ingestor)
 {
   Task::ConstBookingPtr booking =
     std::make_shared<const rmf_task::Task::Booking>(
     id,
     earliest_start_time,
     std::move(priority),
-    std::move(requester),
-    std::move(request_time),
+    automatic);
+  const auto description = Description::make(
+    pickup_waypoint,
+    pickup_wait,
+    dropoff_waypoint,
+    dropoff_wait,
+    std::move(payload),
+    std::move(pickup_from_dispenser),
+    std::move(dropoff_to_ingestor));
+  return std::make_shared<Request>(
+    std::move(booking),
+    std::move(description));
+}
+
+//==============================================================================
+ConstRequestPtr Delivery::make(
+  std::size_t pickup_waypoint,
+  rmf_traffic::Duration pickup_wait,
+  std::size_t dropoff_waypoint,
+  rmf_traffic::Duration dropoff_wait,
+  Payload payload,
+  const std::string& id,
+  rmf_traffic::Time earliest_start_time,
+  const std::string& requester,
+  rmf_traffic::Time request_time,
+  ConstPriorityPtr priority,
+  bool automatic,
+  std::string pickup_from_dispenser,
+  std::string dropoff_to_ingestor)
+{
+  Task::ConstBookingPtr booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+    id,
+    earliest_start_time,
+    std::move(priority),
+    requester,
+    request_time,
     automatic);
   const auto description = Description::make(
     pickup_waypoint,

--- a/rmf_task/src/rmf_task/requests/Delivery.cpp
+++ b/rmf_task/src/rmf_task/requests/Delivery.cpp
@@ -338,9 +338,9 @@ ConstRequestPtr Delivery::make(
     id,
     earliest_start_time,
     std::move(priority),
-    automatic,
     std::move(requester),
-    std::move(request_time));
+    std::move(request_time),
+    automatic);
   const auto description = Description::make(
     pickup_waypoint,
     pickup_wait,

--- a/rmf_task/src/rmf_task/requests/Loop.cpp
+++ b/rmf_task/src/rmf_task/requests/Loop.cpp
@@ -301,9 +301,9 @@ ConstRequestPtr Loop::make(
     id,
     earliest_start_time,
     std::move(priority),
-    automatic,
     std::move(requester),
-    std::move(request_time));
+    std::move(request_time),
+    automatic);
   const auto description = Description::make(
     start_waypoint,
     finish_waypoint,

--- a/rmf_task/src/rmf_task/requests/Loop.cpp
+++ b/rmf_task/src/rmf_task/requests/Loop.cpp
@@ -292,40 +292,18 @@ ConstRequestPtr Loop::make(
   const std::string& id,
   rmf_traffic::Time earliest_start_time,
   ConstPriorityPtr priority,
-  bool automatic)
-{
-  return make(
-    start_waypoint,
-    finish_waypoint,
-    num_loops,
-    id,
-    earliest_start_time,
-    earliest_start_time,
-    priority,
-    "",
-    automatic);
-}
-
-//==============================================================================
-ConstRequestPtr Loop::make(
-  std::size_t start_waypoint,
-  std::size_t finish_waypoint,
-  std::size_t num_loops,
-  const std::string& id,
-  rmf_traffic::Time earliest_start_time,
-  rmf_traffic::Time request_time,
-  ConstPriorityPtr priority,
-  const std::string& requester,
-  bool automatic)
+  bool automatic,
+  std::optional<std::string> requester,
+  std::optional<rmf_traffic::Time> request_time)
 {
   Task::ConstBookingPtr booking =
     std::make_shared<const rmf_task::Task::Booking>(
     id,
     earliest_start_time,
-    request_time,
     std::move(priority),
-    requester,
-    automatic);
+    automatic,
+    std::move(requester),
+    std::move(request_time));
   const auto description = Description::make(
     start_waypoint,
     finish_waypoint,

--- a/rmf_task/src/rmf_task/requests/Loop.cpp
+++ b/rmf_task/src/rmf_task/requests/Loop.cpp
@@ -292,17 +292,42 @@ ConstRequestPtr Loop::make(
   const std::string& id,
   rmf_traffic::Time earliest_start_time,
   ConstPriorityPtr priority,
-  bool automatic,
-  std::optional<std::string> requester,
-  std::optional<rmf_traffic::Time> request_time)
+  bool automatic)
 {
   Task::ConstBookingPtr booking =
     std::make_shared<const rmf_task::Task::Booking>(
     id,
     earliest_start_time,
     std::move(priority),
-    std::move(requester),
-    std::move(request_time),
+    automatic);
+  const auto description = Description::make(
+    start_waypoint,
+    finish_waypoint,
+    num_loops);
+  return std::make_shared<Request>(
+    std::move(booking),
+    std::move(description));
+}
+
+//==============================================================================
+ConstRequestPtr Loop::make(
+  std::size_t start_waypoint,
+  std::size_t finish_waypoint,
+  std::size_t num_loops,
+  const std::string& id,
+  rmf_traffic::Time earliest_start_time,
+  const std::string& requester,
+  rmf_traffic::Time request_time,
+  ConstPriorityPtr priority,
+  bool automatic)
+{
+  Task::ConstBookingPtr booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+    id,
+    earliest_start_time,
+    std::move(priority),
+    requester,
+    request_time,
     automatic);
   const auto description = Description::make(
     start_waypoint,

--- a/rmf_task/src/rmf_task/requests/Loop.cpp
+++ b/rmf_task/src/rmf_task/requests/Loop.cpp
@@ -294,14 +294,43 @@ ConstRequestPtr Loop::make(
   ConstPriorityPtr priority,
   bool automatic)
 {
+  return make(
+    start_waypoint,
+    finish_waypoint,
+    num_loops,
+    id,
+    earliest_start_time,
+    earliest_start_time,
+    priority,
+    "",
+    automatic);
+}
+
+//==============================================================================
+ConstRequestPtr Loop::make(
+    std::size_t start_waypoint,
+    std::size_t finish_waypoint,
+    std::size_t num_loops,
+    const std::string& id,
+    rmf_traffic::Time earliest_start_time,
+    rmf_traffic::Time request_time,
+    ConstPriorityPtr priority,
+    const std::string& initiator,
+    bool automatic)
+{
+  Task::ConstBookingPtr booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+    id,
+    earliest_start_time,
+    request_time,
+    std::move(priority),
+    initiator,
+    automatic);
   const auto description = Description::make(
     start_waypoint,
     finish_waypoint,
     num_loops);
-
-  return std::make_shared<Request>(
-    id, earliest_start_time, std::move(priority), description, automatic);
-
+  return std::make_shared<Request>(std::move(booking), description);
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/Loop.cpp
+++ b/rmf_task/src/rmf_task/requests/Loop.cpp
@@ -308,15 +308,15 @@ ConstRequestPtr Loop::make(
 
 //==============================================================================
 ConstRequestPtr Loop::make(
-    std::size_t start_waypoint,
-    std::size_t finish_waypoint,
-    std::size_t num_loops,
-    const std::string& id,
-    rmf_traffic::Time earliest_start_time,
-    rmf_traffic::Time request_time,
-    ConstPriorityPtr priority,
-    const std::string& requester,
-    bool automatic)
+  std::size_t start_waypoint,
+  std::size_t finish_waypoint,
+  std::size_t num_loops,
+  const std::string& id,
+  rmf_traffic::Time earliest_start_time,
+  rmf_traffic::Time request_time,
+  ConstPriorityPtr priority,
+  const std::string& requester,
+  bool automatic)
 {
   Task::ConstBookingPtr booking =
     std::make_shared<const rmf_task::Task::Booking>(

--- a/rmf_task/src/rmf_task/requests/Loop.cpp
+++ b/rmf_task/src/rmf_task/requests/Loop.cpp
@@ -308,7 +308,9 @@ ConstRequestPtr Loop::make(
     start_waypoint,
     finish_waypoint,
     num_loops);
-  return std::make_shared<Request>(std::move(booking), description);
+  return std::make_shared<Request>(
+    std::move(booking),
+    std::move(description));
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/Loop.cpp
+++ b/rmf_task/src/rmf_task/requests/Loop.cpp
@@ -315,7 +315,7 @@ ConstRequestPtr Loop::make(
     rmf_traffic::Time earliest_start_time,
     rmf_traffic::Time request_time,
     ConstPriorityPtr priority,
-    const std::string& initiator,
+    const std::string& requester,
     bool automatic)
 {
   Task::ConstBookingPtr booking =
@@ -324,7 +324,7 @@ ConstRequestPtr Loop::make(
     earliest_start_time,
     request_time,
     std::move(priority),
-    initiator,
+    requester,
     automatic);
   const auto description = Description::make(
     start_waypoint,

--- a/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
@@ -49,6 +49,8 @@ class ParkRobotFactory::Implementation
 {
 public:
 
+  std::string requester;
+
   std::optional<std::size_t> parking_waypoint;
 };
 
@@ -57,6 +59,20 @@ ParkRobotFactory::ParkRobotFactory(
   std::optional<std::size_t> parking_waypoint)
 : _pimpl(rmf_utils::make_impl<Implementation>(
       Implementation{
+        "",
+        parking_waypoint
+      }))
+{
+  // Do nothing
+}
+
+//==============================================================================
+ParkRobotFactory::ParkRobotFactory(
+  const std::string& requester,
+  std::optional<std::size_t> parking_waypoint)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        requester,
         parking_waypoint
       }))
 {
@@ -79,7 +95,9 @@ ConstRequestPtr ParkRobotFactory::make_request(
     1,
     id,
     state.time().value(),
+    state.time().value(),
     nullptr,
+    _pimpl->requester,
     true);
 
   return request;

--- a/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
@@ -49,31 +49,19 @@ class ParkRobotFactory::Implementation
 {
 public:
 
-  std::string requester;
-
   std::optional<std::size_t> parking_waypoint;
+
+  std::optional<std::string> requester;
 };
 
 //==============================================================================
 ParkRobotFactory::ParkRobotFactory(
-  std::optional<std::size_t> parking_waypoint)
+  std::optional<std::size_t> parking_waypoint,
+  std::optional<std::string> requester)
 : _pimpl(rmf_utils::make_impl<Implementation>(
       Implementation{
-        "",
-        parking_waypoint
-      }))
-{
-  // Do nothing
-}
-
-//==============================================================================
-ParkRobotFactory::ParkRobotFactory(
-  const std::string& requester,
-  std::optional<std::size_t> parking_waypoint)
-: _pimpl(rmf_utils::make_impl<Implementation>(
-      Implementation{
-        requester,
-        parking_waypoint
+        parking_waypoint,
+        std::move(requester)
       }))
 {
   // Do nothing
@@ -95,11 +83,10 @@ ConstRequestPtr ParkRobotFactory::make_request(
     1,
     id,
     state.time().value(),
-    state.time().value(),
     nullptr,
+    true,
     _pimpl->requester,
-    true);
-
+    state.time().value());
   return request;
 }
 

--- a/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
@@ -50,7 +50,6 @@ class ParkRobotFactory::Implementation
 public:
 
   std::optional<std::size_t> parking_waypoint;
-
   std::optional<std::string> requester;
 };
 

--- a/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
@@ -60,6 +60,28 @@ ParkRobotFactory::ParkRobotFactory(
 }
 
 //==============================================================================
+ConstRequestPtr ParkRobotFactory::make_request(const State& state) const
+{
+  std::string id = "ParkRobot" + generate_uuid();
+  const auto start_waypoint = state.waypoint().value();
+  const auto finish_waypoint = _pimpl->parking_waypoint.has_value() ?
+    _pimpl->parking_waypoint.value() :
+    state.dedicated_charging_waypoint().value();
+
+  const auto request = Loop::make(
+    start_waypoint,
+    finish_waypoint,
+    1,
+    id,
+    state.time().value(),
+    nullptr,
+    true,
+    std::nullopt,
+    std::nullopt);
+  return request;
+}
+
+//==============================================================================
 ConstRequestPtr ParkRobotFactory::make_request(
   const State& state,
   const std::string& requester,

--- a/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
@@ -48,13 +48,25 @@ std::string generate_uuid(const std::size_t length = 3)
 class ParkRobotFactory::Implementation
 {
 public:
+  std::optional<std::string> requester;
   std::optional<std::size_t> parking_waypoint;
 };
 
 //==============================================================================
 ParkRobotFactory::ParkRobotFactory(
   std::optional<std::size_t> parking_waypoint)
-: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{parking_waypoint}))
+: _pimpl(rmf_utils::make_impl<Implementation>(
+  Implementation{std::nullopt, std::move(parking_waypoint)}))
+{
+  // Do nothing
+}
+
+//==============================================================================
+ParkRobotFactory::ParkRobotFactory(
+  const std::string& requester,
+  std::optional<std::size_t> parking_waypoint)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+  Implementation{requester, std::move(parking_waypoint)}))
 {
   // Do nothing
 }
@@ -68,42 +80,27 @@ ConstRequestPtr ParkRobotFactory::make_request(const State& state) const
     _pimpl->parking_waypoint.value() :
     state.dedicated_charging_waypoint().value();
 
-  const auto request = Loop::make(
+  if (_pimpl->requester.has_value())
+  {
+    return Loop::make(
+      start_waypoint,
+      finish_waypoint,
+      1,
+      id,
+      state.time().value(),
+      _pimpl->requester.value(),
+      state.time().value(),
+      nullptr,
+      true);
+  }
+  return Loop::make(
     start_waypoint,
     finish_waypoint,
     1,
     id,
     state.time().value(),
     nullptr,
-    true,
-    std::nullopt,
-    std::nullopt);
-  return request;
-}
-
-//==============================================================================
-ConstRequestPtr ParkRobotFactory::make_request(
-  const State& state,
-  const std::string& requester,
-  rmf_traffic::Time time_now) const
-{
-  std::string id = "ParkRobot" + generate_uuid();
-  const auto start_waypoint = state.waypoint().value();
-  const auto finish_waypoint = _pimpl->parking_waypoint.has_value() ?
-    _pimpl->parking_waypoint.value() :
-    state.dedicated_charging_waypoint().value();
-
-  const auto request = Loop::make(
-    start_waypoint,
-    finish_waypoint,
-    1,
-    id,
-    state.time().value(),
-    nullptr,
-    true,
-    requester,
-    time_now);
-  return request;
+    true);;
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
@@ -56,7 +56,7 @@ public:
 ParkRobotFactory::ParkRobotFactory(
   std::optional<std::size_t> parking_waypoint)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-  Implementation{std::nullopt, std::move(parking_waypoint)}))
+      Implementation{std::nullopt, std::move(parking_waypoint)}))
 {
   // Do nothing
 }
@@ -66,7 +66,7 @@ ParkRobotFactory::ParkRobotFactory(
   const std::string& requester,
   std::optional<std::size_t> parking_waypoint)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-  Implementation{requester, std::move(parking_waypoint)}))
+      Implementation{requester, std::move(parking_waypoint)}))
 {
   // Do nothing
 }
@@ -100,7 +100,7 @@ ConstRequestPtr ParkRobotFactory::make_request(const State& state) const
     id,
     state.time().value(),
     nullptr,
-    true);;
+    true);
 }
 
 } // namespace requests

--- a/rmf_task_sequence/test/unit/test_ComposedTaskPlanning.cpp
+++ b/rmf_task_sequence/test/unit/test_ComposedTaskPlanning.cpp
@@ -22,6 +22,7 @@
 #include <rmf_battery/agv/SimpleDevicePowerSink.hpp>
 
 #include <rmf_task/BinaryPriorityScheme.hpp>
+#include <rmf_task/Task.hpp>
 #include <rmf_task/TaskPlanner.hpp>
 
 #include <rmf_task_sequence/Event.hpp>
@@ -145,23 +146,32 @@ SCENARIO("Test GoToPlace and PerformAction Compose task")
   builder.add_phase(action_phase, {});
   auto action_task = builder.build("mock_category", "mock_tag");
 
+  rmf_task::Task::ConstBookingPtr compose_booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+      "mock_id",
+      std::chrono::steady_clock::now(),
+      nullptr);
   auto compose_request = std::make_shared<rmf_task::Request>(
-    "mock_id",
-    std::chrono::steady_clock::now(),
-    nullptr,
-    compose_task);
+    std::move(compose_booking),
+    std::move(compose_task));
 
+  rmf_task::Task::ConstBookingPtr gotoplace_booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+      "mock_id2",
+      std::chrono::steady_clock::now(),
+      nullptr);
   auto gotoplace_request = std::make_shared<rmf_task::Request>(
-    "mock_id2",
-    std::chrono::steady_clock::now(),
-    nullptr,
-    gotoplace_task);
+    std::move(gotoplace_booking),
+    std::move(gotoplace_task));
 
+  rmf_task::Task::ConstBookingPtr action_booking =
+    std::make_shared<const rmf_task::Task::Booking>(
+      "mock_id3",
+      std::chrono::steady_clock::now(),
+      nullptr);
   auto action_request = std::make_shared<rmf_task::Request>(
-    "mock_id3",
-    std::chrono::steady_clock::now(),
-    nullptr,
-    action_task);
+    std::move(action_booking),
+    std::move(action_task));
 
   WHEN("Planning for a task with a gotoplace and perform_action phase")
   {


### PR DESCRIPTION
## New feature implementation

### Implemented feature

<!-- Briefly describe the feature being implemented.
If there is a feature request issue for the feature, link to that feature.
If there is not a feature request issue for the feature, create one first and fill out all the required information there, then link to that issue from this new feature pull request. -->

Related to https://github.com/open-rmf/rmf_api_msgs/pull/35,

* Adds missing constructor implementation for `rmf_task::Request`
* Adds new constructor for `rmf_task::Task::Booking` to include task request time and requester
* Added new `make(...)` API for different types of requests
* New constructors for request factories that accept a `requester` input, which will be propagated into each request they create
* fixed some misc linting errors