### PR TITLE
Provide a setting for charge tasks to run indefinitely

### DIFF
--- a/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
@@ -63,6 +63,16 @@ public:
       const State& initial_state,
       const Parameters& parameters) const final;
 
+    /// Set the charging task to run indefinitely. This means it will never
+    /// declare itself as finished and must instead be canceled. This can be
+    /// used for idle tasks that are canceled automatically when a task request
+    /// comes in. If indefinite is false, the robot will charge up to its
+    /// designated recharge level.
+    void set_indefinite(bool value);
+
+    /// Should this recharge task run indefinitely?
+    bool indefinite() const;
+
     class Implementation;
   private:
     Description();

--- a/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
@@ -56,6 +56,16 @@ public:
     const std::string& requester,
     std::function<rmf_traffic::Time()> time_now_cb);
 
+  /// Set the charging task to run indefinitely. This means it will never
+  /// declare itself as finished and must instead be canceled. This can be used
+  /// for idle tasks that are canceled automatically when a task request comes
+  /// in. If indefinite is false, the robot will charge up to its designated
+  /// recharge level.
+  void set_indefinite(bool value);
+
+  /// Does this factory produce charging requests that will run indefinitely?
+  bool indefinite() const;
+
   /// Documentation inherited
   ConstRequestPtr make_request(const State& state) const final;
 

--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -80,7 +80,8 @@ ChargeBattery::Model::Model(
 
 //==============================================================================
 std::optional<rmf_task::Estimate>
-ChargeBattery::Model::estimate_finish(const State& initial_state,
+ChargeBattery::Model::estimate_finish(
+  const State& initial_state,
   const Constraints& task_planning_constraints,
   const TravelEstimator& travel_estimator) const
 {
@@ -162,7 +163,8 @@ rmf_traffic::Duration ChargeBattery::Model::invariant_duration() const
 //==============================================================================
 class ChargeBattery::Description::Implementation
 {
-
+public:
+  bool indefinite = false;
 };
 
 //==============================================================================
@@ -199,6 +201,18 @@ auto ChargeBattery::Description::generate_info(
     "Charge battery",
     ""
   };
+}
+
+//==============================================================================
+void ChargeBattery::Description::set_indefinite(bool value)
+{
+  _pimpl->indefinite = value;
+}
+
+//==============================================================================
+bool ChargeBattery::Description::indefinite() const
+{
+  return _pimpl->indefinite;
 }
 
 //==============================================================================

--- a/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
@@ -27,6 +27,7 @@ class ChargeBatteryFactory::Implementation
 public:
   std::optional<std::string> requester;
   std::function<rmf_traffic::Time()> time_now_cb;
+  bool indefinite = false;
 };
 
 //==============================================================================
@@ -45,6 +46,18 @@ ChargeBatteryFactory::ChargeBatteryFactory(
       Implementation{requester, std::move(time_now_cb)}))
 {
   // Do nothing
+}
+
+//==============================================================================
+void ChargeBatteryFactory::set_indefinite(bool value)
+{
+  _pimpl->indefinite = value;
+}
+
+//==============================================================================
+bool ChargeBatteryFactory::indefinite() const
+{
+  return _pimpl->indefinite;
 }
 
 //==============================================================================

--- a/rmf_task/src/rmf_task/requests/Loop.cpp
+++ b/rmf_task/src/rmf_task/requests/Loop.cpp
@@ -78,6 +78,7 @@ Loop::Model::Model(
     auto itinerary_start_time = _earliest_start_time;
     double forward_battery_drain = 0.0;
     rmf_traffic::Duration forward_duration(0);
+
     for (const auto& itinerary : forward_loop_plan->get_itinerary())
     {
       const auto& trajectory = itinerary.trajectory();

--- a/rmf_task/src/rmf_task/requests/Loop.cpp
+++ b/rmf_task/src/rmf_task/requests/Loop.cpp
@@ -78,7 +78,6 @@ Loop::Model::Model(
     auto itinerary_start_time = _earliest_start_time;
     double forward_battery_drain = 0.0;
     rmf_traffic::Duration forward_duration(0);
-
     for (const auto& itinerary : forward_loop_plan->get_itinerary())
     {
       const auto& trajectory = itinerary.trajectory();


### PR DESCRIPTION
We will be introducing a concept of an idle task (to replace the concept of a finishing task) which will be canceled automatically when a task request comes in.

To differentiate between a charging task that only wants the robot to reach a certain battery level, vs an idle charging task that wants the robot to remain at the charger until canceled, we are introducing an `indefinite` field to the `ChargeBattery` description.