### PR TITLE
Fix the production of indefinite charging tasks

### DIFF
--- a/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
@@ -53,6 +53,9 @@ public:
     /// Generate the description for this request
     static Task::ConstDescriptionPtr make();
 
+    /// Make a charging task that will last indefinitely.
+    static std::shared_ptr<Description> make_indefinite();
+
     // Documentation inherited
     Task::ConstModelPtr make_model(
       rmf_traffic::Time earliest_start_time,

--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -176,6 +176,15 @@ Task::ConstDescriptionPtr ChargeBattery::Description::make()
 }
 
 //==============================================================================
+auto ChargeBattery::Description::make_indefinite()
+-> std::shared_ptr<Description>
+{
+  std::shared_ptr<Description> description(new Description);
+  description->set_indefinite(true);
+  return description;
+}
+
+//==============================================================================
 ChargeBattery::Description::Description()
 : _pimpl(rmf_utils::make_impl<Implementation>(Implementation()))
 {

--- a/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
@@ -17,9 +17,31 @@
 
 #include <rmf_task/requests/ChargeBatteryFactory.hpp>
 #include <rmf_task/requests/ChargeBattery.hpp>
+#include <random>
 
 namespace rmf_task {
 namespace requests {
+
+//==============================================================================
+namespace {
+std::string generate_uuid(const std::size_t length = 3)
+{
+  std::stringstream ss;
+  for (std::size_t i = 0; i < length; ++i)
+  {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dis(0, 255);
+    const auto random_char = dis(gen);
+    std::stringstream hexstream;
+    hexstream << std::hex << random_char;
+    auto hex = hexstream.str();
+    ss << (hex.length() < 2 ? '0' + hex : hex);
+  }
+  return ss.str();
+}
+
+} // anonymous namespace
 
 //==============================================================================
 class ChargeBatteryFactory::Implementation
@@ -63,20 +85,33 @@ bool ChargeBatteryFactory::indefinite() const
 //==============================================================================
 ConstRequestPtr ChargeBatteryFactory::make_request(const State& state) const
 {
-
+  const std::string id = "Charge" + generate_uuid();
+  Task::ConstBookingPtr booking;
   if (_pimpl->requester.has_value() && _pimpl->time_now_cb)
   {
-    return ChargeBattery::make(
+    booking =
+      std::make_shared<const rmf_task::Task::Booking>(
+      std::move(id),
       state.time().value(),
+      nullptr,
       _pimpl->requester.value(),
       _pimpl->time_now_cb(),
+      true);
+  }
+  else
+  {
+    booking =
+      std::make_shared<const rmf_task::Task::Booking>(
+      std::move(id),
+      state.time().value(),
       nullptr,
       true);
   }
-  return ChargeBattery::make(
-    state.time().value(),
-    nullptr,
-    true);
+
+  const auto description = ChargeBattery::Description::make_indefinite();
+  description->set_indefinite(_pimpl->indefinite);
+
+  return std::make_shared<Request>(std::move(booking), std::move(description));
 }
 
 } // namespace requests


### PR DESCRIPTION
Even though we added the `set_indefinite(bool)` method to the charge task factory, it wasn't actually being used (whoops).

This PR makes sure that indefinite charging tasks are produced by the factory when the user has requested it.