### PR TITLE
More cautious sequence advancing

### DIFF
--- a/rmf_task_sequence/src/rmf_task_sequence/events/Sequence.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/events/Sequence.cpp
@@ -380,8 +380,8 @@ void Sequence::Active::next()
     _reverse_remaining.pop_back();
 
     const auto event_finished = [
-        me = weak_from_this(),
-        event_index_plus_one = _current_event_index_plus_one
+      me = weak_from_this(),
+      event_index_plus_one = _current_event_index_plus_one
       ]()
       {
         if (const auto self = me.lock())

--- a/rmf_task_sequence/src/rmf_task_sequence/events/Sequence.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/events/Sequence.cpp
@@ -366,12 +366,6 @@ void Sequence::Active::next()
 
   BoolGuard lock(_inside_next);
 
-  const auto event_finished = [me = weak_from_this()]()
-    {
-      if (const auto self = me.lock())
-        self->next();
-    };
-
   do
   {
     if (_reverse_remaining.empty())
@@ -384,6 +378,19 @@ void Sequence::Active::next()
     ++_current_event_index_plus_one;
     const auto next_event = _reverse_remaining.back();
     _reverse_remaining.pop_back();
+
+    const auto event_finished = [
+        me = weak_from_this(),
+        event_index_plus_one = _current_event_index_plus_one
+      ]()
+      {
+        if (const auto self = me.lock())
+        {
+          if (event_index_plus_one == self->_current_event_index_plus_one)
+            self->next();
+        }
+      };
+
     _current = next_event->begin(_checkpoint, event_finished);
   } while (_current->state()->finished());
 


### PR DESCRIPTION
There is a risk that a downstream event implementation could cause the sequence to advance multiple times, e.g. by incorrectly calling its `finished` callback. This PR prevents that by checking whether we have already processed the event advancement when the `finished` callback is triggered.