### PR TITLE
Cancellation phase

### DIFF
--- a/rmf_task/include/rmf_task/events/SimpleEventState.hpp
+++ b/rmf_task/include/rmf_task/events/SimpleEventState.hpp
@@ -47,6 +47,11 @@ public:
   // Documentation inherited
   uint64_t id() const final;
 
+  /// Change the ID of this event state. Use this with great caution; the ID is
+  /// generally meant to remain constant. This method is only provided for very
+  /// niche cases.
+  SimpleEventState& modify_id(uint64_t new_id);
+
   // Documentation inherited
   Status status() const final;
 

--- a/rmf_task/src/rmf_task/events/SimpleEventState.cpp
+++ b/rmf_task/src/rmf_task/events/SimpleEventState.cpp
@@ -64,6 +64,13 @@ uint64_t SimpleEventState::id() const
 }
 
 //==============================================================================
+SimpleEventState& SimpleEventState::modify_id(uint64_t new_id)
+{
+  _pimpl->id = new_id;
+  return *this;
+}
+
+//==============================================================================
 Event::Status SimpleEventState::status() const
 {
   return _pimpl->status;

--- a/rmf_task_sequence/src/rmf_task_sequence/Task.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/Task.cpp
@@ -15,6 +15,8 @@
  *
 */
 
+#include "phases/internal_CancellationPhase.hpp"
+
 #include <list>
 
 #include <rmf_task/phases/RestoreBackup.hpp>
@@ -831,28 +833,63 @@ void Task::Active::_begin_next_stage(std::optional<nlohmann::json> restore)
 
     const auto phase_id = tag->id();
     _current_phase_start_time = _clock();
-    _active_phase = _phase_activator->activate(
-      _get_state,
-      _parameters,
-      std::move(tag),
-      *_active_stage->description,
-      std::move(restore),
-      [me = weak_from_this()](Phase::ConstSnapshotPtr snapshot)
-      {
-        if (const auto self = me.lock())
-          self->_update(snapshot);
-      },
-      [me = weak_from_this(), id = phase_id](
-        Phase::Active::Backup backup)
-      {
-        if (const auto self = me.lock())
-          self->_issue_backup(id, std::move(backup));
-      },
-      [me = weak_from_this()]()
-      {
-        if (const auto self = me.lock())
-          self->_finish_phase();
-      });
+
+    if (_cancelled_on_phase.has_value())
+    {
+      auto inner_phase = _phase_activator->activate(
+        _get_state,
+        _parameters,
+        tag,
+        *_active_stage->description,
+        std::move(restore),
+        [me = weak_from_this()](Phase::ConstSnapshotPtr snapshot)
+        {
+          if (const auto self = me.lock())
+          {
+            const auto active_phase = self->_active_phase;
+            if (active_phase)
+              self->_update(Phase::Snapshot::make(*active_phase));
+          }
+        },
+        [me = weak_from_this(), id = phase_id](
+          Phase::Active::Backup backup)
+        {
+          if (const auto self = me.lock())
+            self->_issue_backup(id, std::move(backup));
+        },
+        [me = weak_from_this()]()
+        {
+          if (const auto self = me.lock())
+            self->_finish_phase();
+        });
+
+      _active_phase = phases::CancellationPhase::make(tag, inner_phase);
+    }
+    else
+    {
+      _active_phase = _phase_activator->activate(
+        _get_state,
+        _parameters,
+        std::move(tag),
+        *_active_stage->description,
+        std::move(restore),
+        [me = weak_from_this()](Phase::ConstSnapshotPtr snapshot)
+        {
+          if (const auto self = me.lock())
+            self->_update(snapshot);
+        },
+        [me = weak_from_this(), id = phase_id](
+          Phase::Active::Backup backup)
+        {
+          if (const auto self = me.lock())
+            self->_issue_backup(id, std::move(backup));
+        },
+        [me = weak_from_this()]()
+        {
+          if (const auto self = me.lock())
+            self->_finish_phase();
+        });
+    }
 
     _update(Phase::Snapshot::make(*_active_phase));
     _issue_backup(phase_id, _active_phase->backup());

--- a/rmf_task_sequence/src/rmf_task_sequence/phases/CancellationPhase.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/phases/CancellationPhase.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "internal_CancellationPhase.hpp"
+
+namespace rmf_task_sequence {
+namespace phases {
+
+//==============================================================================
+std::shared_ptr<CancellationPhase> CancellationPhase::make(
+  ConstTagPtr tag,
+  std::shared_ptr<Phase::Active> phase)
+{
+  auto result = std::shared_ptr<CancellationPhase>(new CancellationPhase);
+  result->_tag = std::move(tag);
+  result->_state = rmf_task::events::SimpleEventState::make(
+    (uint64_t)(-1),
+    result->_tag->header().category(),
+    result->_tag->header().detail(),
+    rmf_task::Event::Status::Canceled,
+    {},
+    nullptr);
+
+  result->_phase = std::move(phase);
+  return result;
+}
+
+//==============================================================================
+auto CancellationPhase::tag() const -> ConstTagPtr
+{
+  return _tag;
+}
+
+//==============================================================================
+Event::ConstStatePtr CancellationPhase::final_event() const
+{
+  const auto child_event = _phase->final_event();
+  _state->update_dependencies({child_event});
+  const auto child_status = child_event->status();
+  if (Event::Status::Blocked == child_status
+    || Event::Status::Error == child_status
+    || Event::Status::Failed == child_status)
+  {
+    // Promote the child status into the overall cancellation phase status
+    // in case something needs the attention of the operator.
+    _state->update_status(child_status);
+  }
+  else
+  {
+    _state->update_status(rmf_task::Event::Status::Canceled);
+  }
+
+  return _state;
+}
+
+//==============================================================================
+rmf_traffic::Duration CancellationPhase::estimate_remaining_time() const
+{
+  return _phase->estimate_remaining_time();
+}
+
+//==============================================================================
+auto CancellationPhase::backup() const -> Backup
+{
+  return _phase->backup();
+}
+
+//==============================================================================
+auto CancellationPhase::interrupt(std::function<void()> task_is_interrupted)
+-> Resume
+{
+  return _phase->interrupt(std::move(task_is_interrupted));
+}
+
+//==============================================================================
+void CancellationPhase::cancel()
+{
+  _phase->cancel();
+}
+
+//==============================================================================
+void CancellationPhase::kill()
+{
+  _phase->kill();
+}
+
+} // namespace phases
+} // namespace rmf_task_sequence

--- a/rmf_task_sequence/src/rmf_task_sequence/phases/internal_CancellationPhase.hpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/phases/internal_CancellationPhase.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_TASK_SEQUENCE__PHASES__INTERNAL_CANCELLATION_PHASE_HPP
+#define SRC__RMF_TASK_SEQUENCE__PHASES__INTERNAL_CANCELLATION_PHASE_HPP
+
+#include <rmf_task/events/SimpleEventState.hpp>
+
+#include <rmf_task_sequence/Phase.hpp>
+
+namespace rmf_task_sequence {
+namespace phases {
+
+class CancellationPhase : public Phase::Active
+{
+public:
+  using ConstTagPtr = rmf_task::Phase::ConstTagPtr;
+
+  static std::shared_ptr<CancellationPhase> make(
+    ConstTagPtr tag,
+    std::shared_ptr<Phase::Active> phase);
+
+  ConstTagPtr tag() const final;
+
+  Event::ConstStatePtr final_event() const final;
+
+  rmf_traffic::Duration estimate_remaining_time() const final;
+
+  Backup backup() const final;
+
+  Resume interrupt(std::function<void()> task_is_interrupted) final;
+
+  void cancel() final;
+
+  void kill() final;
+
+private:
+  CancellationPhase() = default;
+
+  ConstTagPtr _tag;
+  rmf_task::events::SimpleEventStatePtr _state;
+  std::shared_ptr<Phase::Active> _phase;
+};
+
+} // namespace phases
+} // namespace rmf_task_sequences
+
+#endif // SRC__RMF_TASK_SEQUENCE__PHASES__INTERNAL_CANCELLATION_PHASE_HPP


### PR DESCRIPTION
It came to our attention that users get understandably confused when a robot enters a cancellation sequence after a task has been canceled because the task status makes it appear as though the cancellation had no effect.

This PR adds a new type of phase called a "cancellation phase" which simply gets wrapped around any phase that belongs to a cancellation sequence. This cancellation phase will give clear indications to users that the task has been successfully canceled and is undertaking a cancellation activity.