### PR TITLE
Fix GoToPlace crash when goal set is empty

### DIFF
--- a/rmf_task_sequence/src/rmf_task_sequence/events/GoToPlace.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/events/GoToPlace.cpp
@@ -84,13 +84,18 @@ Activity::ConstModelPtr GoToPlace::Model::make(
   const Parameters& parameters,
   const std::vector<Goal>& goals)
 {
+  if (goals.empty())
+  {
+    return nullptr;
+  }
+
   auto invariant_finish_state = invariant_initial_state;
 
   auto selected_goal = goals[0];
   std::optional<rmf_traffic::Duration> shortest_travel_time = std::nullopt;
   if (invariant_initial_state.waypoint().has_value())
   {
-    for (auto goal: goals)
+    for (const auto& goal: goals)
     {
       const auto invariant_duration_opt = estimate_duration(
         parameters.planner(),

--- a/rmf_task_sequence/test/unit/events/test_GoToPlace.cpp
+++ b/rmf_task_sequence/test/unit/events/test_GoToPlace.cpp
@@ -25,7 +25,6 @@ SCENARIO("Test GoToPlace")
 {
   using GoToPlace = rmf_task_sequence::events::GoToPlace;
 
-  auto description = GoToPlace::Description::make_for_one_of({0, 8, 12});
   const auto parameters = make_test_parameters();
   const auto constraints = make_test_constraints();
   const auto now = std::chrono::steady_clock::now();
@@ -38,8 +37,19 @@ SCENARIO("Test GoToPlace")
 
   const auto travel_estimator = rmf_task::TravelEstimator(*parameters);
 
+  WHEN("Goal set is empty")
+  {
+    auto description = GoToPlace::Description::make_for_one_of({});
+    THEN("make_model should return nullptr")
+    {
+      const auto model = description->make_model(initial_state, *parameters);
+      CHECK(model == nullptr);
+    }
+  }
+
   WHEN("Not constrained to any map")
   {
+    auto description = GoToPlace::Description::make_for_one_of({0, 8, 12});
     const auto model = description->make_model(initial_state, *parameters);
     const auto finish = model->estimate_finish(
       initial_state, now, *constraints, travel_estimator);
@@ -50,6 +60,7 @@ SCENARIO("Test GoToPlace")
 
   WHEN("Constrained to the same map")
   {
+    auto description = GoToPlace::Description::make_for_one_of({0, 8, 12});
     description->prefer_same_map(true);
     const auto model = description->make_model(initial_state, *parameters);
     const auto finish = model->estimate_finish(


### PR DESCRIPTION
Due to human error it is possible to submit a task with a `GoToPlace` phase with an empty set of goals.

Fix https://github.com/open-rmf/rmf_task/pull/101#discussion_r1503778761
