### PR TITLE
Do not segfault when models cannot be generated

### DIFF
--- a/rmf_task_sequence/src/rmf_task_sequence/Task.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/Task.cpp
@@ -102,6 +102,9 @@ public:
     const Constraints& task_planning_constraints,
     const TravelEstimator& travel_estimator) const final
   {
+    if (!_activity_model)
+      return std::nullopt;
+
     return _activity_model->estimate_finish(
       initial_state,
       _earliest_start_time,
@@ -111,6 +114,9 @@ public:
 
   rmf_traffic::Duration invariant_duration() const final
   {
+    if (!_activity_model)
+      return rmf_traffic::Duration(0);
+
     return _activity_model->invariant_duration();
   }
 
@@ -758,8 +764,9 @@ void Task::Active::_generate_pending_phases()
       )
     );
 
-    state = s->description->make_model(
-      state, *_parameters)->invariant_finish_state();
+    auto model = s->description->make_model(state, *_parameters);
+    if (model)
+      state = model->invariant_finish_state();
   }
 }
 

--- a/rmf_task_sequence/src/rmf_task_sequence/events/Bundle.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/events/Bundle.cpp
@@ -178,9 +178,9 @@ public:
       duration_estimate = adjust_estimate(
         duration_estimate, element_header.original_duration_estimate());
 
-      initial_state =
-        element->make_model(initial_state, parameters)
-        ->invariant_finish_state();
+      auto model = element->make_model(initial_state, parameters);
+      if (model)
+        initial_state = model->invariant_finish_state();
 
       if (detail_json.has_value())
       {

--- a/rmf_task_sequence/src/rmf_task_sequence/events/GoToPlace.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/events/GoToPlace.cpp
@@ -316,8 +316,10 @@ Header GoToPlace::Description::generate_header(
 
   if (!estimate.has_value())
   {
-    utils::fail(fail_header, "Cannot find a path from ["
-      + start_name + "] to any of [" + destination_name(parameters) + "]");
+    Header(
+      "Go to one of [" + destination_name(parameters) + "]",
+      "Waiting for path to open up",
+      rmf_traffic::Duration(0));
   }
 
   auto goal_name = [&](const rmf_traffic::agv::Plan::Goal& goal)

--- a/rmf_task_sequence/src/rmf_task_sequence/phases/SimplePhase.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/phases/SimplePhase.cpp
@@ -33,8 +33,10 @@ public:
     const State& initial_state,
     const Parameters& parameters) const
   {
-    const auto duration =
-      final_event->make_model(initial_state, parameters)->invariant_duration();
+    auto duration = rmf_traffic::Duration(0);
+    const auto model = final_event->make_model(initial_state, parameters);
+    if (model)
+      duration = model->invariant_duration();
 
     if (category.has_value() && detail.has_value())
       return Header(*category, *detail, duration);


### PR DESCRIPTION
There may be cases where GoToPlace models temporarily cannot be generated, i.e. when too many lanes are closed, leaving no viable path to a goal. Since the lanes may be opened at a later time, we need to allow the workflow to move past the model generation phase even if models cannot be generated.

With this PR, we will accept some inaccuracies during model generation in order to move forward with task activation ..but this time without crashing.