### PR TITLE
Add request_type identifier and configurable retreat_to_charger

### DIFF
--- a/rmf_task/include/rmf_task/Constraints.hpp
+++ b/rmf_task/include/rmf_task/Constraints.hpp
@@ -42,10 +42,16 @@ public:
   /// \param[in] drain_battery
   ///   If true, battery drain will be considered during task allocation and
   ///   ChargeBattery tasks will automatically be included if necessary.
+  ///
+  /// \param[in] retreat_to_charger
+  ///   If true, a Charge task will automatically be added for the robot if it
+  ///   is estimated to have its battery soc fall below its recharge_soc before
+  ///   reaching a charger
   Constraints(
     double threshold_soc,
     double recharge_soc = 1.0,
-    bool drain_battery = true);
+    bool drain_battery = true,
+    bool retreat_to_charger = true);
 
   /// Gets the vehicle's state of charge threshold value.
   double threshold_soc() const;
@@ -66,6 +72,12 @@ public:
 
   /// Set the value of drain_battery
   Constraints& drain_battery(bool drain_battery);
+
+  /// Get the value of retreat_to_charger
+  bool retreat_to_charger() const;
+
+  /// Set the value of retreat_to_charger
+  Constraints& retreat_to_charger(bool retreat_to_charger);
 
   class Implementation;
 private:

--- a/rmf_task/include/rmf_task/RequestFactory.hpp
+++ b/rmf_task/include/rmf_task/RequestFactory.hpp
@@ -36,6 +36,9 @@ public:
   ///   request.
   virtual ConstRequestPtr make_request(const State& state) const = 0;
 
+  /// Returns an identifier representing the request type.
+  virtual const std::string& request_type() const = 0;
+
   virtual ~RequestFactory() = default;
 };
 

--- a/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBatteryFactory.hpp
@@ -69,6 +69,9 @@ public:
   /// Documentation inherited
   ConstRequestPtr make_request(const State& state) const final;
 
+  /// Documentation inherited
+  const std::string& request_type() const final;
+
   class Implementation;
 
 private:

--- a/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
+++ b/rmf_task/include/rmf_task/requests/ParkRobotFactory.hpp
@@ -72,6 +72,9 @@ public:
   /// Documentation inherited
   ConstRequestPtr make_request(const State& state) const final;
 
+  /// Documentation inherited
+  const std::string& request_type() const final;
+
   class Implementation;
 
 private:

--- a/rmf_task/src/rmf_task/Constraints.cpp
+++ b/rmf_task/src/rmf_task/Constraints.cpp
@@ -28,19 +28,22 @@ public:
   double threshold_soc;
   double recharge_soc;
   bool drain_battery;
+  bool retreat_to_charger;
 };
 
 //==============================================================================
 Constraints::Constraints(
   double threshold_soc,
   double recharge_soc,
-  bool drain_battery)
+  bool drain_battery,
+  bool retreat_to_charger)
 : _pimpl(rmf_utils::make_impl<Implementation>(
       Implementation
       {
         threshold_soc,
         recharge_soc,
-        drain_battery
+        drain_battery,
+        retreat_to_charger
       }))
 {
   if (threshold_soc < 0.0 || threshold_soc > 1.0)
@@ -113,6 +116,20 @@ auto Constraints::drain_battery(
   bool drain_battery) -> Constraints&
 {
   _pimpl->drain_battery = drain_battery;
+  return *this;
+}
+
+//==============================================================================
+bool Constraints::retreat_to_charger() const
+{
+  return _pimpl->retreat_to_charger;
+}
+
+//==============================================================================
+auto Constraints::retreat_to_charger(
+  bool retreat_to_charger) -> Constraints&
+{
+  _pimpl->retreat_to_charger = retreat_to_charger;
   return *this;
 }
 

--- a/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBatteryFactory.cpp
@@ -50,6 +50,7 @@ public:
   std::optional<std::string> requester;
   std::function<rmf_traffic::Time()> time_now_cb;
   bool indefinite = false;
+  std::string request_type = "Charge";
 };
 
 //==============================================================================
@@ -85,7 +86,7 @@ bool ChargeBatteryFactory::indefinite() const
 //==============================================================================
 ConstRequestPtr ChargeBatteryFactory::make_request(const State& state) const
 {
-  const std::string id = "Charge" + generate_uuid();
+  const std::string id = _pimpl->request_type + generate_uuid();
   Task::ConstBookingPtr booking;
   if (_pimpl->requester.has_value() && _pimpl->time_now_cb)
   {
@@ -112,6 +113,12 @@ ConstRequestPtr ChargeBatteryFactory::make_request(const State& state) const
   description->set_indefinite(_pimpl->indefinite);
 
   return std::make_shared<Request>(std::move(booking), std::move(description));
+}
+
+//==============================================================================
+const std::string& ChargeBatteryFactory::request_type() const
+{
+  return _pimpl->request_type;
 }
 
 } // namespace requests

--- a/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
+++ b/rmf_task/src/rmf_task/requests/ParkRobotFactory.cpp
@@ -51,6 +51,7 @@ public:
   std::optional<std::string> requester;
   std::function<rmf_traffic::Time()> time_now_cb;
   std::optional<std::size_t> parking_waypoint;
+  const std::string request_type = "ParkRobot";
 };
 
 //==============================================================================
@@ -76,7 +77,7 @@ ParkRobotFactory::ParkRobotFactory(
 //==============================================================================
 ConstRequestPtr ParkRobotFactory::make_request(const State& state) const
 {
-  std::string id = "ParkRobot" + generate_uuid();
+  std::string id = _pimpl->request_type + generate_uuid();
   const auto start_waypoint = state.waypoint().value();
   const auto finish_waypoint = _pimpl->parking_waypoint.has_value() ?
     _pimpl->parking_waypoint.value() :
@@ -103,6 +104,12 @@ ConstRequestPtr ParkRobotFactory::make_request(const State& state) const
     state.time().value(),
     nullptr,
     true);
+}
+
+//==============================================================================
+const std::string& ParkRobotFactory::request_type() const
+{
+  return _pimpl->request_type;
 }
 
 } // namespace requests


### PR DESCRIPTION
This PR
- Adds `retreat_to_charger` to the task planner params, enabling it to be configured from the fleet config
- Adds a virtual get function in RequestFactory and implement them to allow request factory identifiers to be retrievable. The identifiers we currently have are `Charge` and `ParkRobot`.