### PR TITLE
Reformat with uncrustify available in noble

### DIFF
--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -13,8 +13,8 @@ jobs:
     uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
     with:
       dist-matrix: |
-          [{"ros_distribution": "humble",
-            "ubuntu_distribution": "jammy"}]
+          [{"ros_distribution": "rolling",
+            "ubuntu_distribution": "noble"}]
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |
         rmf_task

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,3 +17,4 @@ jobs:
       packages: |
         rmf_task
         rmf_task_sequence
+      dist-matrix: '[{"ros_distribution": "rolling", "ubuntu_distribution": "noble"}]'

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -13,8 +13,8 @@ jobs:
     uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
     with:
       dist-matrix: |
-          [{"ros_distribution": "humble",
-            "ubuntu_distribution": "jammy"}]
+          [{"ros_distribution": "rolling",
+            "ubuntu_distribution": "noble"}]
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |
         rmf_task

--- a/rmf_task/include/rmf_task/CompositeData.hpp
+++ b/rmf_task/include/rmf_task/CompositeData.hpp
@@ -110,7 +110,9 @@ private:
 /// instance. The defined class will contain only one field whose type is
 /// specified by Type. The name of the class will be Name.
 #define RMF_TASK_DEFINE_COMPONENT(Type, Name) \
-  struct Name { Type value; Name(Type input) : value(input) {} }
+        struct Name { Type value; Name(Type input)\
+          : value(input) {}\
+        }
 
 #include <rmf_task/detail/impl_CompositeData.hpp>
 

--- a/rmf_task/src/rmf_task/BackupFileManager.cpp
+++ b/rmf_task/src/rmf_task/BackupFileManager.cpp
@@ -288,8 +288,11 @@ std::optional<std::string> BackupFileManager::Robot::read() const
     if (filename.compare(_pimpl->backup_file_name) != 0 &&
       filename.compare(_pimpl->pre_backup_file_name) != 0)
     {
-      throw std::runtime_error("[BackupFileManager::Robot::read] Foreign file " +
-              filename + " found. This should be removed.");
+      // *INDENT-OFF*
+      throw std::runtime_error(
+        "[BackupFileManager::Robot::read] Foreign file " +
+        filename + " found. This should be removed.");
+      // *INDENT-ON*
     }
   }
 

--- a/rmf_task/src/rmf_task/Log.cpp
+++ b/rmf_task/src/rmf_task/Log.cpp
@@ -40,7 +40,8 @@ public:
   {
     if (!clock)
     {
-      clock = []()
+      clock =
+        []()
         {
           return rmf_traffic::Time(
             rmf_traffic::Duration(

--- a/rmf_task/src/rmf_task/TaskPlanner.cpp
+++ b/rmf_task/src/rmf_task/TaskPlanner.cpp
@@ -661,7 +661,8 @@ public:
 
     initial_node->sort_invariants();
 
-    initial_node->latest_time = [&]() -> rmf_traffic::Time
+    initial_node->latest_time =
+      [&]() -> rmf_traffic::Time
       {
         rmf_traffic::Time latest = rmf_traffic::Time::min();
         for (const auto& s : initial_states)

--- a/rmf_task/src/rmf_task/internal_task_planning.cpp
+++ b/rmf_task/src/rmf_task/internal_task_planning.cpp
@@ -50,10 +50,16 @@ void Candidates::update_candidate(
 {
   const auto it = _candidate_map.at(candidate);
   _value_map.erase(it);
-  _candidate_map[candidate] = _value_map.insert(
+  _candidate_map[candidate] =
+    _value_map.insert(
     {
       state.time().value(),
-      Entry{candidate, state, wait_until, previous_state, require_charge_battery}
+      Entry{
+        candidate,
+        state,
+        wait_until,
+        previous_state,
+        require_charge_battery}
     });
 }
 

--- a/rmf_task/test/integration/test_backups.cpp
+++ b/rmf_task/test/integration/test_backups.cpp
@@ -26,7 +26,8 @@
 const std::filesystem::path backup_root_dir = "/tmp/rmf_task/test_backups";
 void cleanup()
 {
-  std::filesystem::remove_all(std::filesystem::weakly_canonical(backup_root_dir));
+  std::filesystem::remove_all(
+    std::filesystem::weakly_canonical(backup_root_dir));
 }
 
 SCENARIO("Backup file creation and clearing tests")

--- a/rmf_task/test/mock/MockDelivery.hpp
+++ b/rmf_task/test/mock/MockDelivery.hpp
@@ -67,9 +67,12 @@ public:
         const uint64_t max_phase_id = pending_phases().size();
         if (phase_id < min_phase_id && phase_id > max_phase_id)
         {
-          throw std::runtime_error("[MockDelivery::Active] phase_id given was " + std::to_string(
-                    phase_id) + " not in range of " + std::to_string(
-                    min_phase_id) + "," + std::to_string(max_phase_id) + ".");
+          // *INDENT-OFF*
+          throw std::runtime_error(
+            "[MockDelivery::Active] phase_id given was " + std::to_string(phase_id) +
+            " not in range of " + std::to_string(min_phase_id) + "," +
+            std::to_string(max_phase_id) + ".");
+          // *INDENT-ON*
         }
         _pending_phases.erase(_pending_phases.begin(),
           _pending_phases.begin()+phase_id);

--- a/rmf_task/test/unit/agv/test_TaskPlanner.cpp
+++ b/rmf_task/test/unit/agv/test_TaskPlanner.cpp
@@ -148,7 +148,8 @@ SCENARIO("Grid World")
   using SimpleDevicePowerSink = rmf_battery::agv::SimpleDevicePowerSink;
 
   rmf_traffic::agv::Graph graph;
-  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
+  auto add_bidir_lane =
+    [&](const std::size_t w0, const std::size_t w1)
     {
       graph.add_lane(w0, w1);
       graph.add_lane(w1, w0);

--- a/rmf_task_sequence/src/rmf_task_sequence/Task.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/Task.cpp
@@ -658,7 +658,8 @@ void Task::Active::_load_backup(std::string backup_state_str)
 
   const auto start_time = _clock();
 
-  const auto failed_to_restore = [&]() -> void
+  const auto failed_to_restore =
+    [&]() -> void
     {
       _pending_stages.clear();
       _phase_finished(

--- a/rmf_task_sequence/src/rmf_task_sequence/events/Bundle.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/events/Bundle.cpp
@@ -309,10 +309,12 @@ void Bundle::add(const Event::InitializerPtr& initializer)
       const auto& initialize_from = w.lock();
       if (!initialize_from)
       {
+        // *INDENT-OFF*
         throw std::runtime_error(
           "[rmf_task_sequence::Bundle::add] Use-after-free error: Event "
           "initializer has already destructed, but is still being used to "
           "initialize an event.");
+        // *INDENT-ON*
       }
 
       return initiate(
@@ -336,10 +338,12 @@ void Bundle::add(const Event::InitializerPtr& initializer)
       const auto& initialize_from = w.lock();
       if (!initialize_from)
       {
+        // *INDENT-OFF*
         throw std::runtime_error(
           "[rmf_task_sequence::Bundle::add] Use-after-free error: Event "
           "initializer has already destructed, but is still being used to "
           "initialize an event.");
+        // *INDENT-ON*
       }
 
       return restore(

--- a/rmf_task_sequence/src/rmf_task_sequence/events/GoToPlace.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/events/GoToPlace.cpp
@@ -327,7 +327,8 @@ Header GoToPlace::Description::generate_header(
       rmf_traffic::Duration(0));
   }
 
-  auto goal_name = [&](const rmf_traffic::agv::Plan::Goal& goal)
+  auto goal_name =
+    [&](const rmf_traffic::agv::Plan::Goal& goal)
     {
       return rmf_task::standard_waypoint_name(
         parameters.planner()->get_configuration().graph(),
@@ -369,7 +370,8 @@ std::string GoToPlace::Description::destination_name(
   if (_pimpl->one_of.empty())
     return "<none>";
 
-  auto goal_name = [&](const rmf_traffic::agv::Plan::Goal& goal)
+  auto goal_name =
+    [&](const rmf_traffic::agv::Plan::Goal& goal)
     {
       return rmf_task::standard_waypoint_name(
         parameters.planner()->get_configuration().graph(),

--- a/rmf_task_sequence/src/rmf_task_sequence/events/Sequence.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/events/Sequence.cpp
@@ -31,7 +31,8 @@ Event::StandbyPtr Sequence::Standby::initiate(
   std::function<void()> parent_update)
 {
   auto state = make_state(id, description);
-  const auto update = [parent_update, state]()
+  const auto update =
+    [parent_update, state]()
     {
       update_status(*state);
       parent_update();
@@ -61,7 +62,8 @@ Event::StandbyPtr Sequence::Standby::initiate(
   rmf_task::events::SimpleEventStatePtr state,
   std::function<void()> parent_update)
 {
-  const auto update = [parent_update, state]()
+  const auto update =
+    [parent_update, state]()
     {
       update_status(*state);
       parent_update();
@@ -172,7 +174,8 @@ Event::ActivePtr Sequence::Active::restore(
   std::function<void()> finished)
 {
   auto state = Sequence::Standby::make_state(id, description);
-  const auto update = [parent_update = std::move(parent_update), state]()
+  const auto update =
+    [parent_update = std::move(parent_update), state]()
     {
       Sequence::Standby::update_status(*state);
       parent_update();
@@ -216,7 +219,8 @@ Event::ActivePtr Sequence::Active::restore(
     std::move(checkpoint),
     std::move(finished));
 
-  const auto event_finished = [me = active->weak_from_this()]()
+  const auto event_finished =
+    [me = active->weak_from_this()]()
     {
       if (const auto self = me.lock())
         self->next();
@@ -379,10 +383,9 @@ void Sequence::Active::next()
     const auto next_event = _reverse_remaining.back();
     _reverse_remaining.pop_back();
 
-    const auto event_finished = [
-      me = weak_from_this(),
-      event_index_plus_one = _current_event_index_plus_one
-      ]()
+    const auto event_finished =
+      [me = weak_from_this(),
+        event_index_plus_one = _current_event_index_plus_one]()
       {
         if (const auto self = me.lock())
         {

--- a/rmf_task_sequence/test/unit/utils.hpp
+++ b/rmf_task_sequence/test/unit/utils.hpp
@@ -106,7 +106,8 @@ std::shared_ptr<rmf_task::Parameters> make_test_parameters(
   graph.add_waypoint(L1, {12, 12}).set_passthrough_point(true); // 12
   REQUIRE(graph.num_waypoints() == 13);
 
-  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
+  auto add_bidir_lane =
+    [&](const std::size_t w0, const std::size_t w1)
     {
       graph.add_lane(w0, w1);
       graph.add_lane(w1, w0);


### PR DESCRIPTION
Running `ament_uncrustify` with `--reformat` leads to some changes that did not fit with the original style guide. In this PR I tweaked some of the code such that it complies. Mostly breaking line before instantiating a lambda and adding `        // *INDENT-OFF*` blocks for throw statements.