### PR TITLE
Introduce start_at_departure option for go_to_place event

### DIFF
--- a/rmf_task_sequence/include/rmf_task_sequence/events/GoToPlace.hpp
+++ b/rmf_task_sequence/include/rmf_task_sequence/events/GoToPlace.hpp
@@ -90,6 +90,14 @@ public:
   /// initial location should always be preferred over any other destinations.
   Description& prefer_same_map(bool choice);
 
+  /// Check whether to interpret the earliest start time as the robot's
+  /// departure time (true) or arrival time (false).
+  bool start_at_departure() const;
+
+  /// Specify whether or not to interpret the earliest start time as the robot's
+  /// departure time (true) or arrival time (false).
+  Description& start_at_departure(bool choice);
+
   // Documentation inherited
   Activity::ConstModelPtr make_model(
     State invariant_initial_state,

--- a/rmf_task_sequence/include/rmf_task_sequence/events/GoToPlace.hpp
+++ b/rmf_task_sequence/include/rmf_task_sequence/events/GoToPlace.hpp
@@ -96,6 +96,12 @@ public:
 
   /// Specify whether or not to interpret the earliest start time as the robot's
   /// departure time (true) or arrival time (false).
+  ///
+  /// default: false
+  /// - false: The robot will try to be at its destination by the
+  ///   earliest start time of the task.
+  /// - true: The robot will not leave its starting point until the
+  ///   earliest start time of the task.
   Description& start_at_departure(bool choice);
 
   // Documentation inherited

--- a/rmf_task_sequence/src/rmf_task_sequence/events/GoToPlace.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/events/GoToPlace.cpp
@@ -56,7 +56,7 @@ public:
   // Documentation inherited
   std::optional<Estimate> estimate_finish(
     State initial_state,
-    rmf_traffic::Time earliest_arrival_time,
+    rmf_traffic::Time earliest_start_time,
     const Constraints& constraints,
     const TravelEstimator& estimator) const final;
 
@@ -135,7 +135,7 @@ Activity::ConstModelPtr GoToPlace::Model::make(
 //==============================================================================
 std::optional<Estimate> GoToPlace::Model::estimate_finish(
   State initial_state,
-  rmf_traffic::Time earliest_arrival_time,
+  rmf_traffic::Time earliest_start_time,
   const Constraints& constraints,
   const TravelEstimator& travel_estimator) const
 {
@@ -149,12 +149,12 @@ std::optional<Estimate> GoToPlace::Model::estimate_finish(
   if (!travel.has_value())
     return std::nullopt;
 
-  const auto arrival_time =
+  const auto start_time =
     std::max(
-    initial_state.time().value() + travel->duration(),
-    earliest_arrival_time);
+    initial_state.time().value(),
+    earliest_start_time);
 
-  const auto wait_until_time = arrival_time - travel->duration();
+  const auto wait_until_time = start_time;
   finish.time(wait_until_time + travel->duration());
 
   if (constraints.drain_battery())

--- a/rmf_task_sequence/src/rmf_task_sequence/events/GoToPlace.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/events/GoToPlace.cpp
@@ -51,12 +51,16 @@ public:
   static Activity::ConstModelPtr make(
     State invariant_initial_state,
     const Parameters& parameters,
-    const std::vector<Goal>& goal);
+    const std::vector<Goal>& goal,
+    const bool start_at_departure);
 
   // Documentation inherited
+  // earliest_time_constraint:
+  //   - _start_at_departure == false: earliest allowed arrival time
+  //   - _start_at_departure == true: earliest allowed departure time
   std::optional<Estimate> estimate_finish(
     State initial_state,
-    rmf_traffic::Time earliest_start_time,
+    rmf_traffic::Time earliest_time_constraint,
     const Constraints& constraints,
     const TravelEstimator& estimator) const final;
 
@@ -71,18 +75,21 @@ private:
   Model(
     State invariant_finish_state,
     rmf_traffic::Duration invariant_duration,
-    Goal goal);
+    Goal goal,
+    const bool start_at_departure);
 
   State _invariant_finish_state;
   rmf_traffic::Duration _invariant_duration;
   Goal _goal;
+  const bool _start_at_departure;
 };
 
 //==============================================================================
 Activity::ConstModelPtr GoToPlace::Model::make(
   State invariant_initial_state,
   const Parameters& parameters,
-  const std::vector<Goal>& goals)
+  const std::vector<Goal>& goals,
+  const bool start_at_departure)
 {
   if (goals.empty())
   {
@@ -129,13 +136,14 @@ Activity::ConstModelPtr GoToPlace::Model::make(
     new Model(
       std::move(invariant_finish_state),
       shortest_travel_time.value_or(rmf_traffic::Duration(0)),
-      std::move(selected_goal)));
+      std::move(selected_goal),
+      start_at_departure));
 }
 
 //==============================================================================
 std::optional<Estimate> GoToPlace::Model::estimate_finish(
   State initial_state,
-  rmf_traffic::Time earliest_start_time,
+  rmf_traffic::Time earliest_time_constraint,
   const Constraints& constraints,
   const TravelEstimator& travel_estimator) const
 {
@@ -149,13 +157,28 @@ std::optional<Estimate> GoToPlace::Model::estimate_finish(
   if (!travel.has_value())
     return std::nullopt;
 
-  const auto start_time =
-    std::max(
-    initial_state.time().value(),
-    earliest_start_time);
+  rmf_traffic::Time wait_until_time;
 
-  const auto wait_until_time = start_time;
-  finish.time(wait_until_time + travel->duration());
+  if (_start_at_departure)
+  {
+    // Event starts at 'departure'. The constraint applies to 'departure'.
+    const auto departure_time =
+      std::max(
+      initial_state.time().value(),
+      earliest_time_constraint);
+    wait_until_time = departure_time;
+    finish.time(departure_time + travel->duration());
+  }
+  else
+  {
+    // Event starts at 'arrival'. The constraint applies to 'arrival'.
+    const auto arrival_time =
+      std::max(
+      initial_state.time().value() + travel->duration(),
+      earliest_time_constraint);
+    wait_until_time = arrival_time - travel->duration();
+    finish.time(arrival_time);
+  }
 
   if (constraints.drain_battery())
   {
@@ -192,10 +215,12 @@ State GoToPlace::Model::invariant_finish_state() const
 GoToPlace::Model::Model(
   State invariant_finish_state,
   rmf_traffic::Duration invariant_duration,
-  Goal goal)
+  Goal goal,
+  const bool start_at_departure)
 : _invariant_finish_state(std::move(invariant_finish_state)),
   _invariant_duration(invariant_duration),
-  _goal(std::move(goal))
+  _goal(std::move(goal)),
+  _start_at_departure(start_at_departure)
 {
   // Do nothing
 }
@@ -207,6 +232,7 @@ public:
   std::vector<rmf_traffic::agv::Plan::Goal> one_of;
   std::vector<rmf_traffic::agv::Plan::Goal> expected_next_destinations;
   bool prefer_same_map = false;
+  bool start_at_departure = false;
 };
 
 //==============================================================================
@@ -248,7 +274,8 @@ Activity::ConstModelPtr GoToPlace::Description::make_model(
         goals.push_back(g);
     }
 
-    const auto model = Model::make(invariant_initial_state, parameters, goals);
+    const auto model = Model::make(
+      invariant_initial_state, parameters, goals, _pimpl->start_at_departure);
     if (model)
       return model;
   }
@@ -256,7 +283,8 @@ Activity::ConstModelPtr GoToPlace::Description::make_model(
   return Model::make(
     std::move(invariant_initial_state),
     parameters,
-    _pimpl->one_of);
+    _pimpl->one_of,
+    _pimpl->start_at_departure);
 }
 
 //==============================================================================
@@ -415,6 +443,19 @@ bool GoToPlace::Description::prefer_same_map() const
 auto GoToPlace::Description::prefer_same_map(bool choice) -> Description&
 {
   _pimpl->prefer_same_map = choice;
+  return *this;
+}
+
+//==============================================================================
+bool GoToPlace::Description::start_at_departure() const
+{
+  return _pimpl->start_at_departure;
+}
+
+//==============================================================================
+auto GoToPlace::Description::start_at_departure(bool choice) -> Description&
+{
+  _pimpl->start_at_departure = choice;
   return *this;
 }
 


### PR DESCRIPTION

## Bug fix

### Fixed bug
**Summary**

This PR addresses a semantic mismatch in how earliest_start_time from a task booking is propagated and interpreted downstream in the task planning pipeline.

**Current Behavior**
	•	The dispatch layer (eg. dispatch_patrol.py) sets [**unix_millis_earliest_start_time**].
	•	This value flows into FleetUpdateHandle.cpp then to PendingTask::make(), where it is stored as earliest_start_time.
	•	However, in GoToPlace.cpp, the argument is received and treated as earliest_arrival_time (in estimate_finish())).

As a result, the planner interprets the constraint as “do not arrive before this time”, while the booking contract intends “do not start before this time.” The "wait_until" return from estimate_finish() is sometime earlier than the [**unix_millis_earliest_start_time**].

This creates a semantic mismatch between task request and task execution.

**Example**
	•	Booking specifies earliest_start_time = 10:00am.
	•	Current behavior: Robot may plan so that it arrives at 10:00am (treating it as arrival gating).
	•	Intended behavior: Robot should only begin traveling no earlier than 10:00am (start gating).




### Fix applied

- Update the function signature and usage in GoToPlace to consistently interpret the value as earliest_start_time (departure gate).

- Aligns planner behavior with the booking contract, ensuring the robot does not begin before the allowed start time.


### Notes for Reviewers

From tracing the variable through the task dispatch json, it appears [**unix_millis_earliest_start_time**] is currently misinterpreted as **earliest_arrival_time** in GoToPlace.

This PR corrects the semantics and logic in GoToPlace, but I would appreciate confirmation from reviewers on whether the original design intent was indeed “start gating” rather than “arrival gating.”

If the original intent was truly to gate arrival, then further discussion may be needed (coz user thought it is earliest start time of the task). Otherwise, this fix resolves both the semantic mismatch and the resulting logic discrepancy.

