### PR TITLE
Resolve warnings

### DIFF
--- a/rmf_task/src/rmf_task/internal_task_planning.hpp
+++ b/rmf_task/src/rmf_task/internal_task_planning.hpp
@@ -186,20 +186,18 @@ struct Node
   {
     unassigned_tasks.erase(task_id);
 
-    bool popped_invariant = false;
-    InvariantSet::iterator erase_it;
+    InvariantSet::iterator erase_it = unassigned_invariants.end();
     for (auto it = unassigned_invariants.begin();
       it != unassigned_invariants.end(); ++it)
     {
       if (it->task_id == task_id)
       {
-        popped_invariant = true;
         erase_it = it;
         break;
       }
     }
+    assert(erase_it != unassigned_invariants.end());
     unassigned_invariants.erase(erase_it);
-    assert(popped_invariant);
   }
 };
 

--- a/rmf_task/test/unit/agv/test_TaskPlanner.cpp
+++ b/rmf_task/test/unit/agv/test_TaskPlanner.cpp
@@ -72,7 +72,7 @@ inline void CHECK_TIMES(const TaskPlanner::Assignments& assignments,
 //==============================================================================
 inline bool check_implicit_charging_task_start(
   const TaskPlanner::Assignments& assignments,
-  const double initial_soc)
+  const double /*initial_soc*/)
 {
   bool implicit_charging_task_added = false;
   for (const auto& agent : assignments)
@@ -82,7 +82,6 @@ inline bool check_implicit_charging_task_start(
       continue;
     }
 
-    const auto& s = agent[0].finish_state();
     auto is_charge_request =
       std::dynamic_pointer_cast<
       const rmf_task::requests::ChargeBattery::Description>(

--- a/rmf_task_sequence/src/rmf_task_sequence/Task.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/Task.cpp
@@ -1035,7 +1035,7 @@ void Task::Active::_begin_next_stage(std::optional<nlohmann::json> restore)
         tag,
         *_active_stage->description,
         std::move(restore),
-        [me = weak_from_this()](Phase::ConstSnapshotPtr snapshot)
+        [me = weak_from_this()](Phase::ConstSnapshotPtr /*snapshot*/)
         {
           if (const auto self = me.lock())
           {
@@ -1209,7 +1209,7 @@ auto Task::make_activator(
       return Active::make(
         phase_activator,
         clock,
-        std::move(get_state),
+        get_state,
         parameters,
         booking,
         description,

--- a/rmf_task_sequence/src/rmf_task_sequence/events/PerformAction.cpp
+++ b/rmf_task_sequence/src/rmf_task_sequence/events/PerformAction.cpp
@@ -80,7 +80,7 @@ std::optional<rmf_task::Estimate> PerformAction::Model::estimate_finish(
   rmf_task::State initial_state,
   rmf_traffic::Time earliest_arrival_time,
   const Constraints& constraints,
-  const TravelEstimator& travel_estimator) const
+  const TravelEstimator& /*travel_estimator*/) const
 {
   initial_state.time(initial_state.time().value() + _invariant_duration);
   if (_invariant_finish_state.waypoint().has_value())

--- a/rmf_task_sequence/test/unit/utils.hpp
+++ b/rmf_task_sequence/test/unit/utils.hpp
@@ -68,7 +68,7 @@ std::shared_ptr<rmf_task::Constraints> make_test_constraints(
 
 //==============================================================================
 std::shared_ptr<rmf_task::Parameters> make_test_parameters(
-  bool drain_battery = true)
+  bool /*drain_battery*/ = true)
 {
   using BatterySystem = rmf_battery::agv::BatterySystem;
   using MechanicalSystem = rmf_battery::agv::MechanicalSystem;
@@ -206,6 +206,7 @@ void CHECK_STATE(
 
 //==============================================================================
 // TODO(YV): Also check for invariant_finish_state
+[[maybe_unused]]
 void CHECK_MODEL(
   const rmf_task_sequence::Activity::Model& model,
   const rmf_task::State& initial_state,
@@ -227,6 +228,7 @@ void CHECK_MODEL(
 }
 
 //==============================================================================
+[[maybe_unused]]
 std::optional<rmf_traffic::Duration> estimate_travel_duration(
   const std::shared_ptr<const rmf_traffic::agv::Planner>& planner,
   const rmf_task::State& initial_state,


### PR DESCRIPTION
## Bug fix

### Fixed bug

Taking inspiration from https://github.com/open-rmf/rmf_traffic/pull/132, I performed source builds of Open-RMF and asked the agent to list out compilation warnings with easy and non-intrusive fixes throughout the code base.

More PRs will be opened in other repositories.

### Fix applied

* resolved a UB (TIL erasing an empty initialized iterator is UB)
* unused variables or parameters
* unnecessary `std::move` calls
* adding `maybe_unused` to make the compiler be happy about unused functions

I've skipped any of the required changes that were too intrusive to reduce the compiler warnings.

Overall stats regarding compilation warnings that were not related to thirdparty libraries or vendored libraries,
* compilation warnings on main: ~187
* after fixes throughout codebase: ~86
* reduced 101 warnings (-54%)

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [x] I used a GenAI tool in this PR.
- [ ] I did not use GenAI

Generated-by: Claude Sonnet 4.6
