### PR TITLE
Lyrical compatibility

### DIFF
--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -17,3 +17,4 @@ jobs:
         rmf_task
         rmf_task_sequence
       mixin: asan
+    repos-branch-override: lyrical

--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   asan_test:
     name: rmf_task asan
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@lyrical
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |

--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   asan_test:
     name: rmf_task asan
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@explicit_libclang-rt-dev
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@lyrical
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |

--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -17,4 +17,4 @@ jobs:
         rmf_task
         rmf_task_sequence
       mixin: asan
-    repos-branch-override: lyrical
+      repos-branch-override: lyrical

--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   asan_test:
     name: rmf_task asan
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@lyrical
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@explicit_libclang-rt-dev
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |

--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   asan_test:
     name: rmf_task asan
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@lyrical
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |

--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -12,9 +12,6 @@ jobs:
     name: rmf_task asan
     uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
     with:
-      dist-matrix: |
-          [{"ros_distribution": "rolling",
-            "ubuntu_distribution": "noble"}]
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |
         rmf_task

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,3 +17,4 @@ jobs:
       packages: |
         rmf_task
         rmf_task_sequence
+    repos-branch-override: lyrical

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_and_test:
     name: rmf_task
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@lyrical
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_and_test:
     name: rmf_task
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@explicit_libclang-rt-dev
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@lyrical
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_and_test:
     name: rmf_task
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@lyrical
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,4 +17,3 @@ jobs:
       packages: |
         rmf_task
         rmf_task_sequence
-      dist-matrix: '[{"ros_distribution": "rolling", "ubuntu_distribution": "noble"}]'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_and_test:
     name: rmf_task
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@lyrical
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@explicit_libclang-rt-dev
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,4 +17,4 @@ jobs:
       packages: |
         rmf_task
         rmf_task_sequence
-    repos-branch-override: lyrical
+      repos-branch-override: lyrical

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -12,9 +12,6 @@ jobs:
     name: rmf_task tsan
     uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
     with:
-      dist-matrix: |
-          [{"ros_distribution": "rolling",
-            "ubuntu_distribution": "noble"}]
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |
         rmf_task

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -17,4 +17,4 @@ jobs:
         rmf_task
         rmf_task_sequence
       mixin: tsan
-    repos-branch-override: lyrical
+      repos-branch-override: lyrical

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   tsan_test:
     name: rmf_task tsan
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@lyrical
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@explicit_libclang-rt-dev
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   tsan_test:
     name: rmf_task tsan
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@lyrical
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   tsan_test:
     name: rmf_task tsan
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@explicit_libclang-rt-dev
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@lyrical
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   tsan_test:
     name: rmf_task tsan
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@lyrical
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       packages: |

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -17,3 +17,4 @@ jobs:
         rmf_task
         rmf_task_sequence
       mixin: tsan
+    repos-branch-override: lyrical

--- a/rmf_task/CMakeLists.txt
+++ b/rmf_task/CMakeLists.txt
@@ -54,7 +54,8 @@ target_include_directories(rmf_task
     ${EIGEN3_INCLUDE_DIRS}
 )
 
-if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND ament_cmake_uncrustify_FOUND)
+option(STYLE_TEST "Run uncrustify to evaluate the code style")
+if(BUILD_TESTING)
   file(GLOB_RECURSE unit_test_srcs "test/*.cpp")
 
   ament_add_catch2(
@@ -71,15 +72,17 @@ if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND ament_cmake_uncrustify_FOUND)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
   )
 
-  find_file(uncrustify_config_file
-    NAMES "rmf_code_style.cfg"
-    PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
+  if(ament_cmake_catch2_FOUND AND STYLE_TEST)
+    find_file(uncrustify_config_file
+      NAMES "rmf_code_style.cfg"
+      PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
-  ament_uncrustify(
-    ARGN include src test
-    CONFIG_FILE ${uncrustify_config_file}
-    MAX_LINE_LENGTH 80
-  )
+    ament_uncrustify(
+      ARGN include src test
+      CONFIG_FILE ${uncrustify_config_file}
+      MAX_LINE_LENGTH 80
+    )
+  endif()
 endif()
 
 

--- a/rmf_task/package.xml
+++ b/rmf_task/package.xml
@@ -19,7 +19,6 @@
   <depend>eigen</depend>
 
   <test_depend>ament_cmake_catch2</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/rmf_task_sequence/CMakeLists.txt
+++ b/rmf_task_sequence/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(rmf_task_sequence
   PUBLIC
     rmf_task::rmf_task
     nlohmann_json::nlohmann_json
-    nlohmann_json_schema_validator
+    nlohmann_json_schema_validator::validator
 )
 
 target_include_directories(rmf_task_sequence

--- a/rmf_task_sequence/CMakeLists.txt
+++ b/rmf_task_sequence/CMakeLists.txt
@@ -52,7 +52,8 @@ target_include_directories(rmf_task_sequence
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/rmf_api_generate_schema_headers/include> # for auto-generated schema headers
 )
 
-if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND ament_cmake_uncrustify_FOUND)
+option(STYLE_TEST "Run uncrustify to evaluate the code style")
+if(BUILD_TESTING AND ament_cmake_catch2_FOUND)
   file(GLOB_RECURSE unit_test_srcs "test/*.cpp")
   ament_add_catch2(
     test_rmf_task_sequence test/main.cpp ${unit_test_srcs}
@@ -66,15 +67,17 @@ if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND ament_cmake_uncrustify_FOUND)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
   )
 
-  find_file(uncrustify_config_file
-    NAMES "rmf_code_style.cfg"
-    PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
+  if(ament_cmake_uncrustify_FOUND AND STYLE_TEST)
+    find_file(uncrustify_config_file
+      NAMES "rmf_code_style.cfg"
+      PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
-  ament_uncrustify(
-    ARGN include src test
-    CONFIG_FILE ${uncrustify_config_file}
-    MAX_LINE_LENGTH 80
-  )
+    ament_uncrustify(
+      ARGN include src test
+      CONFIG_FILE ${uncrustify_config_file}
+      MAX_LINE_LENGTH 80
+    )
+  endif()
 endif()
 
 # Generate the schema headers

--- a/rmf_task_sequence/include/rmf_task_sequence/detail/impl_Phase.hpp
+++ b/rmf_task_sequence/include/rmf_task_sequence/detail/impl_Phase.hpp
@@ -38,12 +38,18 @@ void Phase::Activator::add_activator(Activate<Desc> activator)
       std::function<void(Active::Backup)> phase_checkpoint,
       std::function<void()> phase_finished)
     {
+      std::optional<nlohmann::json> json_backup_state = std::nullopt;
+      if (backup_state.has_value())
+      {
+        json_backup_state = nlohmann::json::parse(*backup_state);
+      }
+
       return activator(
         get_state,
         parameters,
         std::move(tag),
         static_cast<const Desc&>(description),
-        std::move(backup_state),
+        std::move(json_backup_state),
         std::move(phase_update),
         std::move(phase_checkpoint),
         std::move(phase_finished));


### PR DESCRIPTION
This PR updates the `rmf_task` repo to be compatible with https://github.com/open-rmf/nlohmann_json_schema_validator_vendor/pull/22 which will be the new version of `nlohmann_json_schema_validator` that gets released on ROS Lyrical.

This will also be backwards compatible, going back to humble, as long as the changes in https://github.com/open-rmf/nlohmann_json_schema_validator_vendor/pull/22 are used alongside it.