### PR TITLE
Add explicit rmf_traffic dependencies

### DIFF
--- a/rmf_task/CMakeLists.txt
+++ b/rmf_task/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(rmf_task SHARED
 target_link_libraries(rmf_task
   PUBLIC
     rmf_battery::rmf_battery
+    rmf_traffic::rmf_traffic
     nlohmann_json::nlohmann_json
     Threads::Threads
     $<$<CXX_COMPILER_ID:GNU>:stdc++fs>

--- a/rmf_task/package.xml
+++ b/rmf_task/package.xml
@@ -14,6 +14,7 @@
 
   <depend>rmf_battery</depend>
   <depend>rmf_utils</depend>
+  <depend>rmf_traffic</depend>
   <depend>nlohmann-json-dev</depend>
 
   <depend>eigen</depend>

--- a/rmf_task_sequence/CMakeLists.txt
+++ b/rmf_task_sequence/CMakeLists.txt
@@ -22,6 +22,7 @@ include(GNUInstallDirs)
 
 find_package(rmf_api_msgs REQUIRED)
 find_package(rmf_task REQUIRED)
+find_package(rmf_traffic REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(nlohmann_json_schema_validator_vendor REQUIRED)
 find_package(nlohmann_json_schema_validator REQUIRED)
@@ -41,6 +42,7 @@ add_library(rmf_task_sequence SHARED
 target_link_libraries(rmf_task_sequence
   PUBLIC
     rmf_task::rmf_task
+    rmf_traffic::rmf_traffic
     nlohmann_json::nlohmann_json
     nlohmann_json_schema_validator::validator
 )

--- a/rmf_task_sequence/cmake/rmf_task_sequence-config.cmake.in
+++ b/rmf_task_sequence/cmake/rmf_task_sequence-config.cmake.in
@@ -5,6 +5,7 @@ get_filename_component(rmf_task_sequence_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" 
 include(CMakeFindDependencyMacro)
 
 find_dependency(rmf_task)
+find_dependency(rmf_traffic)
 find_dependency(nlohmann_json)
 find_dependency(nlohmann_json_schema_validator_vendor)
 find_dependency(nlohmann_json_schema_validator)

--- a/rmf_task_sequence/package.xml
+++ b/rmf_task_sequence/package.xml
@@ -14,6 +14,7 @@
 
   <depend>rmf_api_msgs</depend>
   <depend>rmf_task</depend>
+  <depend>rmf_traffic</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>nlohmann_json_schema_validator_vendor</depend>
 


### PR DESCRIPTION
This PR adds explicit `rmf_traffic` dependency declarations for `rmf_task` and `rmf_task_sequence`.

Both packages directly use `rmf_traffic` types in their public headers and implementation code. For example:

- `rmf_task` includes `rmf_traffic/Time.hpp`, `rmf_traffic/Trajectory.hpp`, and `rmf_traffic/agv/Planner.hpp` in request/task planning headers.
- `rmf_task_sequence` uses `rmf_traffic::Time`, `rmf_traffic::Duration`, and `rmf_traffic::agv::Plan::Goal` in its public task, activity, and event APIs.

Currently these packages can receive `rmf_traffic` transitively through other RMF dependencies, but the direct source usage is not fully reflected in package metadata.

Changes:

- Add `<depend>rmf_traffic</depend>` to `rmf_task/package.xml`.
- Add `<depend>rmf_traffic</depend>` to `rmf_task_sequence/package.xml`.
- Add `find_package(rmf_traffic REQUIRED)` to `rmf_task_sequence/CMakeLists.txt`.
- Link `rmf_task_sequence` against `rmf_traffic::rmf_traffic`.
- Link `rmf_task` against `rmf_traffic::rmf_traffic`.
- Add `find_dependency(rmf_traffic)` to `rmf_task_sequence`'s exported CMake config.

`rmf_task` already had `find_package(rmf_traffic REQUIRED)` and `find_dependency(rmf_traffic)`, so the change there only updates `package.xml` to match the existing CMake dependency.